### PR TITLE
test: add testRule with initial rule unit tests

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,6 +49,8 @@ export default tseslint.config(
 			},
 		},
 		rules: {
+			"n/no-missing-import": "off",
+
 			// Stylistic concerns that don't interfere with Prettier
 			"logical-assignment-operators": [
 				"error",

--- a/package.json
+++ b/package.json
@@ -82,6 +82,7 @@
 		"prettier-plugin-sh": "0.17.2",
 		"release-it": "19.0.1",
 		"sentences-per-line": "0.3.0",
+		"type-fest": "^4.40.0",
 		"typescript": "5.8.2",
 		"typescript-eslint": "8.30.1",
 		"vitest": "3.1.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,6 +135,9 @@ importers:
       sentences-per-line:
         specifier: 0.3.0
         version: 0.3.0
+      type-fest:
+        specifier: ^4.40.0
+        version: 4.40.0
       typescript:
         specifier: 5.8.2
         version: 5.8.2
@@ -3195,8 +3198,8 @@ packages:
     resolution: {integrity: sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==}
     engines: {node: '>=12.20'}
 
-  type-fest@4.39.1:
-    resolution: {integrity: sha512-uW9qzd66uyHYxwyVBYiwS4Oi0qZyUqwjU+Oevr6ZogYiXt99EOYtwvzMSLw1c3lYo2HzJsep/NB23iEVEgjG/w==}
+  type-fest@4.40.0:
+    resolution: {integrity: sha512-ABHZ2/tS2JkvH1PEjxFDTUWC8dB5OsIGZP4IFLhR293GqT5Y5qB1WwL2kMPYhQW9DVgVD8Hd7I8gjwPIf5GFkw==}
     engines: {node: '>=16'}
 
   typedarray@0.0.6:
@@ -6250,7 +6253,7 @@ snapshots:
     dependencies:
       '@babel/code-frame': 7.26.2
       index-to-position: 1.1.0
-      type-fest: 4.39.1
+      type-fest: 4.40.0
 
   parse-ms@4.0.0: {}
 
@@ -6362,14 +6365,14 @@ snapshots:
     dependencies:
       find-up-simple: 1.0.1
       read-pkg: 9.0.1
-      type-fest: 4.39.1
+      type-fest: 4.40.0
 
   read-pkg@9.0.1:
     dependencies:
       '@types/normalize-package-data': 2.4.4
       normalize-package-data: 6.0.2
       parse-json: 8.3.0
-      type-fest: 4.39.1
+      type-fest: 4.40.0
       unicorn-magic: 0.1.0
 
   readable-stream@3.6.2:
@@ -6704,7 +6707,7 @@ snapshots:
 
   type-fest@2.19.0: {}
 
-  type-fest@4.39.1: {}
+  type-fest@4.40.0: {}
 
   typedarray@0.0.6: {}
 

--- a/src/execution/runRuleOnEntity.ts
+++ b/src/execution/runRuleOnEntity.ts
@@ -1,0 +1,22 @@
+import type { Entity } from "../types/entities.js";
+import type { Rule, RuleContext } from "../types/rules.js";
+
+export async function runRuleOnEntity(
+	context: RuleContext,
+	rule: Rule,
+	entity: Entity,
+) {
+	switch (entity.type) {
+		case "comment":
+			await rule.comment?.(context, entity);
+			break;
+
+		case "issue":
+			await rule.issue?.(context, entity);
+			break;
+
+		case "pull_request":
+			await rule.pullRequest?.(context, entity);
+			break;
+	}
+}

--- a/src/octoguide.ts
+++ b/src/octoguide.ts
@@ -2,6 +2,7 @@ import { octokitFromAuth } from "octokit-from-auth";
 
 import type { RuleContext, RuleReport } from "./types/rules.js";
 
+import { runRuleOnEntity } from "./execution/runRuleOnEntity.js";
 import { resolveLintable } from "./resolvers/resolveEntity.js";
 import { rules } from "./rules/index.js";
 
@@ -36,19 +37,7 @@ export async function runOctoGuide({ githubToken, url }: OctoGuideSettings) {
 				},
 			};
 
-			switch (entity.type) {
-				case "comment":
-					await rule.comment?.(context, entity);
-					break;
-
-				case "issue":
-					await rule.issue?.(context, entity);
-					break;
-
-				case "pull_request":
-					await rule.pullRequest?.(context, entity);
-					break;
-			}
+			await runRuleOnEntity(context, rule, entity);
 		}),
 	);
 

--- a/src/rules/commentMeaningless.test.ts
+++ b/src/rules/commentMeaningless.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { testRule } from "../tests/testRule.js";
+import { commentMeaningless } from "./commentMeaningless.js";
+
+describe(commentMeaningless.about.name, () => {
+	it("does not report when the comment has no body text", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			commentMeaningless,
+			{
+				data: {
+					body: "",
+				},
+				type: "comment",
+			},
+			{ report },
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("does not report when the comment has meaningful body text", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			commentMeaningless,
+			{
+				data: {
+					body: "mmh, yes, indeed, a fine point, thank you 🧐",
+				},
+				type: "comment",
+			},
+			{ report },
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("reports when the comment has meaningless body text", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			commentMeaningless,
+			{
+				data: {
+					body: "+1",
+				},
+				type: "comment",
+			},
+			{ report },
+		);
+
+		expect(report).toHaveBeenCalledWith({
+			primary:
+				"Saying just '+1' is unnecessary: it doesn't add any new information to the discussion.",
+			secondary: [
+				"Although your enthusiasm is appreciated, posting a new comment gives everyone subscribed to the thread.",
+				"It's generally better to give a GitHub emoji reaction instead.",
+			],
+		});
+	});
+});

--- a/src/rules/prBranchNonDefault.test.ts
+++ b/src/rules/prBranchNonDefault.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { testRule } from "../tests/testRule.js";
+import { prBranchNonDefault } from "./prBranchNonDefault.js";
+
+const get = vi.fn().mockResolvedValue({
+	data: {
+		default_branch: "main",
+	},
+});
+
+describe(prBranchNonDefault.about.name, () => {
+	it("does not report when the pull request has a different head than the default branch", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prBranchNonDefault,
+			{
+				data: {
+					head: {
+						ref: "patch-1",
+					},
+				},
+				type: "pull_request",
+			},
+			{
+				octokit: {
+					rest: {
+						repos: {
+							// https://github.com/sindresorhus/type-fest/issues/1107
+							// @ts-expect-error -- this should be fully partial
+							get,
+						},
+					},
+				},
+				report,
+			},
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("reports when the pull request has the same head as the default branch", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prBranchNonDefault,
+			{
+				data: {
+					head: {
+						ref: "main",
+					},
+				},
+				type: "pull_request",
+			},
+			{
+				octokit: {
+					rest: {
+						repos: {
+							// https://github.com/sindresorhus/type-fest/issues/1107
+							// @ts-expect-error -- this should be fully partial
+							get,
+						},
+					},
+				},
+				report,
+			},
+		);
+
+		expect(report).toHaveBeenCalledWith({
+			primary: "This PR is sent from the head repository's default branch",
+			secondary: [
+				`Sending a PR from a default branch means the head repository can't easily be updated after the PR is merged.`,
+				`Please create a new branch and send the PR from there.`,
+			],
+		});
+	});
+});

--- a/src/rules/prLinkedIssue.test.ts
+++ b/src/rules/prLinkedIssue.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { testRule } from "../tests/testRule.js";
+import { prLinkedIssue } from "./prLinkedIssue.js";
+
+describe(prLinkedIssue.about.name, () => {
+	it("does not report when the pull request has a closing issue reference", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prLinkedIssue,
+			{
+				data: {
+					head: {
+						ref: "patch-1",
+					},
+				},
+				id: 2,
+				type: "pull_request",
+			},
+			{
+				octokit: {
+					// https://github.com/sindresorhus/type-fest/issues/1107
+					// @ts-expect-error -- this should be fully partial
+					graphql: vi.fn().mockResolvedValue({
+						repository: {
+							pullRequest: {
+								closingIssuesReferences: {
+									nodes: [{ number: 1 }],
+								},
+							},
+						},
+					}),
+				},
+				report,
+			},
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("reports when the pull request does not have a closing issue reference", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prLinkedIssue,
+			{
+				data: {
+					head: {
+						ref: "main",
+					},
+				},
+				id: 2,
+				type: "pull_request",
+			},
+			{
+				octokit: {
+					// https://github.com/sindresorhus/type-fest/issues/1107
+					// @ts-expect-error -- this should be fully partial
+					graphql: vi.fn().mockResolvedValue({
+						repository: {
+							pullRequest: {
+								closingIssuesReferences: {
+									nodes: [],
+								},
+							},
+						},
+					}),
+				},
+				report,
+			},
+		);
+
+		expect(report).toHaveBeenCalledWith({
+			primary: "This pull request is not linked as closing any issues.",
+		});
+	});
+});

--- a/src/rules/prLinkedIssue.ts
+++ b/src/rules/prLinkedIssue.ts
@@ -19,8 +19,7 @@ export const prLinkedIssue = {
 		name: "pr-linked-issue",
 	},
 	async pullRequest(context, entity) {
-		// eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
-		const response = (await context.octokit.graphql(
+		const response = await context.octokit.graphql<ClosingIssuesResponse>(
 			`
 				query closingIssues($id: Int!, $owner: String!, $repository: String!) {
 					repository(owner: $owner, name: $repository) {
@@ -39,7 +38,7 @@ export const prLinkedIssue = {
 				owner: context.locator.owner,
 				repository: context.locator.repository,
 			},
-		)) as ClosingIssuesResponse;
+		);
 
 		if (response.repository.pullRequest.closingIssuesReferences.nodes.length) {
 			return;

--- a/src/rules/prTaskCompletion.test.ts
+++ b/src/rules/prTaskCompletion.test.ts
@@ -1,0 +1,283 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { testRule } from "../tests/testRule.js";
+import { prTaskCompletion } from "./prTaskCompletion.js";
+
+describe(prTaskCompletion.about.name, () => {
+	it("does not report when there is no PR template", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prTaskCompletion,
+			{
+				data: {
+					body: "",
+				},
+				type: "pull_request",
+			},
+			{
+				octokit: {
+					rest: {
+						repos: {
+							// https://github.com/sindresorhus/type-fest/issues/1107
+							// @ts-expect-error -- this should be fully partial
+							getContent: vi.fn().mockRejectedValue(new Error("Not found")),
+						},
+					},
+				},
+				report,
+			},
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("does not report when the PR template response has array data", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prTaskCompletion,
+			{
+				data: {
+					body: "",
+				},
+				type: "pull_request",
+			},
+			{
+				octokit: {
+					rest: {
+						repos: {
+							// https://github.com/sindresorhus/type-fest/issues/1107
+							// @ts-expect-error -- this should be fully partial
+							getContent: vi.fn().mockResolvedValueOnce({
+								data: [],
+							}),
+						},
+					},
+				},
+				report,
+			},
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("does not report when the PR template response is not a file", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prTaskCompletion,
+			{
+				data: {
+					body: "",
+				},
+				type: "pull_request",
+			},
+			{
+				octokit: {
+					rest: {
+						repos: {
+							// https://github.com/sindresorhus/type-fest/issues/1107
+							// @ts-expect-error -- this should be fully partial
+							getContent: vi.fn().mockResolvedValueOnce({
+								data: {
+									type: "dir",
+								},
+							}),
+						},
+					},
+				},
+				report,
+			},
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("does not report when the PR template response has no tasks", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prTaskCompletion,
+			{
+				data: {
+					body: "",
+				},
+				type: "pull_request",
+			},
+			{
+				octokit: {
+					rest: {
+						repos: {
+							// https://github.com/sindresorhus/type-fest/issues/1107
+							// @ts-expect-error -- this should be fully partial
+							getContent: vi.fn().mockResolvedValueOnce({
+								data: {
+									content: "Just send it.",
+									type: "file",
+								},
+							}),
+						},
+					},
+				},
+				report,
+			},
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("reports when the template has tasks and the pull request body is empty", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prTaskCompletion,
+			{
+				data: {
+					body: "",
+				},
+				type: "pull_request",
+			},
+			{
+				octokit: {
+					rest: {
+						repos: {
+							// https://github.com/sindresorhus/type-fest/issues/1107
+							// @ts-expect-error -- this should be fully partial
+							getContent: vi.fn().mockResolvedValueOnce({
+								data: {
+									content: Buffer.from("- [ ] Task 1\n- [ ] Task 2").toString(
+										"base64",
+									),
+									type: "file",
+								},
+							}),
+						},
+					},
+				},
+				report,
+			},
+		);
+
+		expect(report).toHaveBeenCalledWith({
+			primary:
+				"This PR's body is empty, but there is a template with tasks to be done.",
+			secondary: [
+				"Please fill out the pull request template and make sure all the tasks are [x] checked.",
+			],
+		});
+	});
+
+	it("reports when the template has tasks and the pull request body only completes one of them", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prTaskCompletion,
+			{
+				data: {
+					body: "- [x] Task 1\n- [ ] Task 2",
+				},
+				type: "pull_request",
+			},
+			{
+				octokit: {
+					rest: {
+						repos: {
+							// https://github.com/sindresorhus/type-fest/issues/1107
+							// @ts-expect-error -- this should be fully partial
+							getContent: vi.fn().mockResolvedValueOnce({
+								data: {
+									content: Buffer.from("- [ ] Task 1\n- [ ] Task 2").toString(
+										"base64",
+									),
+									type: "file",
+								},
+							}),
+						},
+					},
+				},
+				report,
+			},
+		);
+
+		expect(report).toHaveBeenCalledWith({
+			primary:
+				"This PR's body is missing [x] checks on the following the tasks from the PR template.",
+			secondary: ["- [ ] Task 2"],
+		});
+	});
+
+	it("reports when the template has tasks and the pull request body completes none of them", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prTaskCompletion,
+			{
+				data: {
+					body: "- [ ] Task 1\n- [ ] Task 2",
+				},
+				type: "pull_request",
+			},
+			{
+				octokit: {
+					rest: {
+						repos: {
+							// https://github.com/sindresorhus/type-fest/issues/1107
+							// @ts-expect-error -- this should be fully partial
+							getContent: vi.fn().mockResolvedValueOnce({
+								data: {
+									content: Buffer.from("- [ ] Task 1\n- [ ] Task 2").toString(
+										"base64",
+									),
+									type: "file",
+								},
+							}),
+						},
+					},
+				},
+				report,
+			},
+		);
+
+		expect(report).toHaveBeenCalledWith({
+			primary:
+				"This PR's body is missing [x] checks on the following the tasks from the PR template.",
+			secondary: ["- [ ] Task 1", "- [ ] Task 2"],
+		});
+	});
+
+	it("does not report when the template has tasks and the pull request body completes all of them", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prTaskCompletion,
+			{
+				data: {
+					body: "- [x] Task 1\n- [x] Task 2",
+				},
+				type: "pull_request",
+			},
+			{
+				octokit: {
+					rest: {
+						repos: {
+							// https://github.com/sindresorhus/type-fest/issues/1107
+							// @ts-expect-error -- this should be fully partial
+							getContent: vi.fn().mockResolvedValueOnce({
+								data: {
+									content: Buffer.from("- [ ] Task 1\n- [ ] Task 2").toString(
+										"base64",
+									),
+									type: "file",
+								},
+							}),
+						},
+					},
+				},
+				report,
+			},
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+});

--- a/src/rules/prTaskCompletion.ts
+++ b/src/rules/prTaskCompletion.ts
@@ -21,8 +21,7 @@ export const prTaskCompletion = {
 		if (
 			!templateResponse ||
 			Array.isArray(templateResponse.data) ||
-			templateResponse.data.type !== "file" ||
-			!templateResponse.data.content
+			templateResponse.data.type !== "file"
 		) {
 			return;
 		}

--- a/src/rules/prTitleConventional.test.ts
+++ b/src/rules/prTitleConventional.test.ts
@@ -1,0 +1,91 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { testRule } from "../tests/testRule.js";
+import { prTitleConventional } from "./prTitleConventional.js";
+
+describe(prTitleConventional.about.name, () => {
+	it("reports when the pull request title is missing a type", async () => {
+		const report = vi.fn();
+		const title = "add this new feature";
+
+		await testRule(
+			prTitleConventional,
+			{
+				data: {
+					title,
+				},
+				type: "pull_request",
+			},
+			{ report },
+		);
+
+		expect(report).toHaveBeenCalledWith({
+			primary: `The PR title is missing a conventional commit type, such as 'docs: ' or 'feat: ':`,
+			secondary: [title],
+		});
+	});
+
+	it("reports when the pull request title has an unknown type", async () => {
+		const report = vi.fn();
+		const title = "other: add this new feature";
+
+		await testRule(
+			prTitleConventional,
+			{
+				data: {
+					title,
+				},
+				type: "pull_request",
+			},
+			{ report },
+		);
+
+		expect(report).toHaveBeenCalledWith({
+			primary: `The PR title has an unknown type: 'other'.`,
+			secondary: [
+				"Known types are: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'",
+				"You'll want to replace the PR type with one of those known types.",
+			],
+		});
+	});
+
+	it("reports when the pull request title is missing a subject", async () => {
+		const report = vi.fn();
+		const title = "feat: ";
+
+		await testRule(
+			prTitleConventional,
+			{
+				data: {
+					title,
+				},
+				type: "pull_request",
+			},
+			{ report },
+		);
+
+		expect(report).toHaveBeenCalledWith({
+			primary: `PR title is missing a subject after its type.`,
+			secondary: [
+				`You'll want to add text after the type, like 'feat: etc. etc.'`,
+			],
+		});
+	});
+
+	it("does not report when the pull request title has both a subject and a type", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prTitleConventional,
+			{
+				data: {
+					title: "feat: add this new feature",
+				},
+				type: "pull_request",
+			},
+			{ report },
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+});

--- a/src/rules/textImageAltText.test.ts
+++ b/src/rules/textImageAltText.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { testRule } from "../tests/testRule.js";
+import { textImageAltText } from "./textImageAltText.js";
+
+describe(textImageAltText.about.name, () => {
+	it("does not report when the entity does not have a body", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			textImageAltText,
+			{
+				data: {},
+				type: "issue",
+			},
+			{ report },
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("does not report when the entity does not have images in its body", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			textImageAltText,
+			{
+				data: {
+					body: "Test body.",
+				},
+				type: "issue",
+			},
+			{ report },
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("does not report when the body has an image with seemingly acceptable alt text.", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			textImageAltText,
+			{
+				data: {
+					body: "![Test image description](img.jpg)",
+				},
+				type: "issue",
+			},
+			{ report },
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("reports when an image is missing alt text.", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			textImageAltText,
+			{
+				data: {
+					body: "![](img.jpg)",
+				},
+				type: "issue",
+			},
+			{ report },
+		);
+
+		expect(report).toHaveBeenCalledWith({
+			primary: "The following image is missing alt text:",
+			secondary: ["![](img.jpg)"],
+		});
+	});
+
+	it("reports when an image has seemingly default alt text.", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			textImageAltText,
+			{
+				data: {
+					body: "![Screen Shot 2025-06-26 at 7 41 30 PM](img.jpg)",
+				},
+				type: "issue",
+			},
+			{ report },
+		);
+
+		expect(report).toHaveBeenCalledWith({
+			primary:
+				"The following image seems to have default alt text, rather than something informative:",
+			secondary: ["![Screen Shot 2025-06-26 at 7 41 30 PM](img.jpg)"],
+		});
+	});
+});

--- a/src/rules/textImageAltText.ts
+++ b/src/rules/textImageAltText.ts
@@ -19,10 +19,6 @@ export const textImageAltText = {
 } satisfies Rule;
 
 function checkEntity(context: RuleContext, entity: Entity) {
-	if (!entity.user) {
-		return;
-	}
-
 	const content = entity.data.body?.trim();
 	if (!content) {
 		return undefined;

--- a/src/tests/createProxiedObject.ts
+++ b/src/tests/createProxiedObject.ts
@@ -1,0 +1,18 @@
+import { PartialDeep } from "type-fest";
+
+export function createProxiedObject<T extends object>(
+	label: string,
+	obj: PartialDeep<T> = {} as PartialDeep<T>,
+): T {
+	return new Proxy(obj, {
+		get(target, property: string) {
+			if (property in target) {
+				return target[property as keyof typeof target];
+			}
+
+			throw new Error(
+				`${label} property '${property}' was used but not provided.`,
+			);
+		},
+	}) as T;
+}

--- a/src/tests/testRule.ts
+++ b/src/tests/testRule.ts
@@ -1,0 +1,44 @@
+import type { PartialDeep } from "type-fest";
+
+import { Octokit } from "octokit";
+
+import type { RepositoryLocator } from "../types/data.js";
+import type { Entity, EntityType } from "../types/entities.js";
+import type { Rule, RuleReporter } from "../types/rules.js";
+
+import { runRuleOnEntity } from "../execution/runRuleOnEntity.js";
+import { createProxiedObject } from "./createProxiedObject.js";
+
+export interface TestRuleContext {
+	locator?: RepositoryLocator;
+	octokit?: PartialDeep<Octokit>;
+	report: RuleReporter;
+}
+
+const defaultLocator = {
+	owner: "test-owner",
+	repository: "test-repo",
+};
+
+export async function testRule(
+	rule: Rule,
+	providedEntity: PartialDeep<Entity> & { type: EntityType },
+	context: TestRuleContext,
+) {
+	const octokit = createProxiedObject<Octokit>(
+		"context.octokit",
+		context.octokit,
+	);
+
+	const entity = createProxiedObject<Entity>("entity", providedEntity);
+
+	await runRuleOnEntity(
+		{
+			locator: defaultLocator,
+			...context,
+			octokit,
+		},
+		rule,
+		entity,
+	);
+}

--- a/src/types/entities.ts
+++ b/src/types/entities.ts
@@ -13,6 +13,8 @@ export interface CommentEntity {
 
 export type Entity = CommentEntity | IssueEntity | PullRequestEntity;
 
+export type EntityType = Entity["type"];
+
 export type IssueData =
 	RestEndpointMethodTypes["issues"]["get"]["response"]["data"];
 

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,7 +9,6 @@ export default defineConfig({
 			reporter: ["html", "lcov"],
 		},
 		exclude: ["lib", "node_modules"],
-		passWithNoTests: true,
 		setupFiles: ["console-fail-test/setup"],
 	},
 });


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #23
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/octoguide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/octoguide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Adds a `testRule` helper that takes in a rule, a deep partial of an entity, and a deep partial of testing context. Those deep partials are set up with `Proxy`s to error if an unknown property is accessed.

🗺️ 