### PR TITLE
fix: implement pagination for comments retrieval

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
 		"@actions/core": "^1.11.1",
 		"@actions/github": "^6.0.0",
 		"@github/markdownlint-github": "^0.7.0",
+		"@octokit/plugin-paginate-rest": "^12.0.0",
 		"@octokit/plugin-rest-endpoint-methods": "^14.0.0",
 		"chalk": "^5.4.1",
 		"conventional-commit-types": "^3.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
       '@github/markdownlint-github':
         specifier: ^0.7.0
         version: 0.7.0
+      '@octokit/plugin-paginate-rest':
+        specifier: ^12.0.0
+        version: 12.0.0(@octokit/core@6.1.5)
       '@octokit/plugin-rest-endpoint-methods':
         specifier: ^14.0.0
         version: 14.0.0(@octokit/core@6.1.5)

--- a/src/actors/DiscussionActorBase.ts
+++ b/src/actors/DiscussionActorBase.ts
@@ -27,9 +27,7 @@ export abstract class DiscussionActorBase<
 	Data extends CommentData | DiscussionData,
 > extends EntityActorBase<Data> {
 	async listComments() {
-		// TODO: Retrieve all comments, not just the first page
-		// https://github.com/JoshuaKGoldberg/OctoGuide/issues/34
-		const response = await this.octokit.request(
+		const iterator = this.octokit.paginate.iterator(
 			"GET /repos/{owner}/{repo}/discussions/{discussion_number}/comments",
 			{
 				discussion_number: this.entityNumber,
@@ -38,7 +36,12 @@ export abstract class DiscussionActorBase<
 			},
 		);
 
-		return response.data as DiscussionCommentData[];
+		const comments: DiscussionCommentData[] = [];
+		for await (const response of iterator) {
+			comments.push(...(response.data as DiscussionCommentData[]));
+		}
+
+		return comments;
 	}
 
 	async updateComment(number: number, newBody: string) {

--- a/src/actors/IssueLikeActorBase.ts
+++ b/src/actors/IssueLikeActorBase.ts
@@ -39,16 +39,16 @@ export abstract class IssueLikeActorBase<
 	abstract getData(): Promise<Data>;
 
 	async listComments() {
-		// TODO: Retrieve all pages, not just the first one
-		// https://github.com/JoshuaKGoldberg/OctoGuide/issues/34
-		const comments = await this.octokit.rest.issues.listComments({
-			issue_number: this.entityNumber,
-			owner: this.locator.owner,
-			per_page: 100,
-			repo: this.locator.repository,
-		});
+		const comments = await this.octokit.paginate(
+			this.octokit.rest.issues.listComments,
+			{
+				issue_number: this.entityNumber,
+				owner: this.locator.owner,
+				repo: this.locator.repository,
+			},
+		);
 
-		return comments.data;
+		return comments;
 	}
 
 	async updateComment(number: number, newBody: string) {

--- a/src/runOctoGuideRules.ts
+++ b/src/runOctoGuideRules.ts
@@ -1,4 +1,6 @@
 import * as core from "@actions/core";
+import { paginateRest } from "@octokit/plugin-paginate-rest";
+import { Octokit } from "octokit";
 import { octokitFromAuth } from "octokit-from-auth";
 
 import type { EntityActor } from "./actors/types.js";
@@ -69,7 +71,11 @@ export async function runOctoGuideRules({
 	// 2. Using that to create the equivalent actor: requires writing
 	// ...where only 1. is needed for runOctoGuide.
 	// https://github.com/JoshuaKGoldberg/OctoGuide/issues/56
-	const octokit = await octokitFromAuth({ auth });
+	const MyOctokit = Octokit.plugin(paginateRest);
+	const octokit = await octokitFromAuth({
+		auth,
+		Octokit: MyOctokit,
+	});
 	const { actor, locator } = createActor(octokit, url);
 	if (!actor) {
 		throw new Error("Could not resolve GitHub entity actor.");


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #34
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/octoguide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/octoguide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

This PR fixes issue #34 by implementing proper pagination when retrieving comments from GitHub API.

Changes:

- Added `@octokit/plugin-paginate-rest` plugin integration in `src/octoguide.ts`
- Updated `listComments()` method in `IssueLikeActorBase.ts` to use pagination
- Updated `listComments()` method in `DiscussionActorBase.ts` to use pagination

The implementation was tested against facebook/react issue 1739 which has over 100 comments. The pagination successfully retrieves all comments across multiple pages.

My test script:

```js
import { paginateRest } from "@octokit/plugin-paginate-rest";
import { Octokit } from "octokit";

async function testPagination() {
	const token = process.env.GITHUB_TOKEN || process.env.GH_TOKEN;
	if (!token) {
		console.error(
			"❌ GitHub token not found! Set GITHUB_TOKEN or GH_TOKEN environment variable",
		);
		process.exit(1);
	}

	const MyOctokit = Octokit.plugin(paginateRest);
	const octokit = new MyOctokit({
		auth: token,
	});

	const owner = "facebook";
	const repo = "react";
	const issue_number = 1739;

	console.log(`\n🔍 Testing pagination for ${owner}/${repo}#${issue_number}\n`);

	try {
		console.time("Execution time");

		console.log("📥 Getting comments with pagination...");
		const comments = await octokit.paginate(octokit.rest.issues.listComments, {
			owner,
			repo,
			issue_number,
		});

		console.log(`✅ Successfully retrieved ${comments.length} comments!`);

		console.log(
			"\n📥 Getting only the first page of comments (without pagination)...",
		);
		const firstPageResponse = await octokit.rest.issues.listComments({
			owner,
			repo,
			issue_number,
			per_page: 100,
		});

		console.log(
			`📄 The first page contains ${firstPageResponse.data.length} comments`,
		);

		const additionalComments = comments.length - firstPageResponse.data.length;
		console.log(
			`🔄 Difference: ${additionalComments} additional comments retrieved through pagination`,
		);

		console.timeEnd("Execution time");

		if (additionalComments > 0) {
			console.log(
				"\n🎉 TEST PASSED: Pagination works and returns more comments!\n",
			);

			if (comments.length > 0) {
				console.log("📌 First comment:");
				console.log(`   ID: ${comments[0].id}`);
				console.log(`   Author: ${comments[0].user.login}`);
				console.log(
					`   Date: ${new Date(comments[0].created_at).toLocaleString()}`,
				);

				console.log("\n📌 Last comment:");
				console.log(`   ID: ${comments[comments.length - 1].id}`);
				console.log(`   Author: ${comments[comments.length - 1].user.login}`);
				console.log(
					`   Date: ${new Date(comments[comments.length - 1].created_at).toLocaleString()}`,
				);
			}
		} else {
			console.log(
				"\n❌ TEST FAILED: Pagination did not provide additional comments.\n",
			);
			console.log("Possible reasons:");
			console.log(`- Issue #${issue_number} has fewer than 100 comments`);
			console.log("- The pagination plugin is not working correctly");
			console.log("- Problem with authorization or GitHub API");
		}
	} catch (error) {
		console.error("\n❌ An error occurred:", error.message);
		if (error.response) {
			console.error("Response details:", error.response.data);
		}
		console.error("\nFull error:", error);
	}
}

testPagination().catch(console.error);
```
