### PR TITLE
fix: use proper PullRequestActor when fetching PR data

### DIFF
--- a/src/action/runOctoGuideAction.ts
+++ b/src/action/runOctoGuideAction.ts
@@ -54,8 +54,6 @@ export async function runOctoGuideAction(context: typeof github.context) {
 		entity: url,
 	});
 
-	core.debug(`Full entity: ${JSON.stringify(entity, null, 2)}`);
-
 	if (reports.length) {
 		core.info(`Found ${reports.length.toString()} report(s).`);
 		console.log(cliReporter(reports));

--- a/src/actors/IssueActor.ts
+++ b/src/actors/IssueActor.ts
@@ -1,0 +1,38 @@
+import type { Octokit } from "octokit";
+
+import type { RepositoryLocator } from "../types/data.js";
+import type {
+	IssueLikeData,
+	IssueLikeEntity,
+	IssueLikeEntityType,
+} from "../types/entities.js";
+
+import { IssueLikeActorBase } from "./IssueLikeActorBase.js";
+
+export class IssueActor extends IssueLikeActorBase<IssueLikeData> {
+	readonly metadata: Omit<IssueLikeEntity, "data">;
+
+	constructor(
+		entityNumber: number,
+		entityType: IssueLikeEntityType,
+		locator: RepositoryLocator,
+		octokit: Octokit,
+	) {
+		super(entityNumber, locator, octokit);
+
+		this.metadata = {
+			number: entityNumber,
+			type: entityType,
+		};
+	}
+
+	async getData() {
+		const { data } = await this.octokit.rest.issues.get({
+			issue_number: this.entityNumber,
+			owner: this.locator.owner,
+			repo: this.locator.repository,
+		});
+
+		return data;
+	}
+}

--- a/src/actors/PullRequestActor.ts
+++ b/src/actors/PullRequestActor.ts
@@ -9,7 +9,7 @@ import type {
 
 import { IssueLikeActorBase } from "./IssueLikeActorBase.js";
 
-export class IssueLikeActor extends IssueLikeActorBase<IssueLikeData> {
+export class PullRequestActor extends IssueLikeActorBase<IssueLikeData> {
 	readonly metadata: Omit<IssueLikeEntity, "data">;
 
 	constructor(
@@ -27,9 +27,9 @@ export class IssueLikeActor extends IssueLikeActorBase<IssueLikeData> {
 	}
 
 	async getData() {
-		const { data } = await this.octokit.rest.issues.get({
-			issue_number: this.entityNumber,
+		const { data } = await this.octokit.rest.pulls.get({
 			owner: this.locator.owner,
+			pull_number: this.entityNumber,
 			repo: this.locator.repository,
 		});
 

--- a/src/actors/createActor.test.ts
+++ b/src/actors/createActor.test.ts
@@ -4,8 +4,9 @@ import { describe, expect, it } from "vitest";
 import { createActor } from "./createActor";
 import { DiscussionActor } from "./DiscussionActor";
 import { DiscussionCommentActor } from "./DiscussionCommentActor";
-import { IssueLikeActor } from "./IssueLikeActor";
+import { IssueActor } from "./IssueActor";
 import { IssueLikeCommentActor } from "./IssueLikeCommentActor";
+import { PullRequestActor } from "./PullRequestActor";
 
 const mockOctokit = {} as Octokit;
 
@@ -52,12 +53,12 @@ describe(createActor, () => {
 		expect(actor).toBeInstanceOf(IssueLikeCommentActor);
 	});
 
-	it("creates an IssueLikeActor when given an issue URL", () => {
+	it("creates an IssueActor when given an issue URL", () => {
 		const url = "https://github.com/owner/repository/issues/123";
 
 		const { actor } = createActor(mockOctokit, url);
 
-		expect(actor).toBeInstanceOf(IssueLikeActor);
+		expect(actor).toBeInstanceOf(IssueActor);
 	});
 
 	it("creates an IssueLikeCommentActor when given a pull request comment URL", () => {
@@ -68,11 +69,11 @@ describe(createActor, () => {
 		expect(actor).toBeInstanceOf(IssueLikeCommentActor);
 	});
 
-	it("creates an IssueLikeActor when given a pull request URL", () => {
+	it("creates a PullRequestActor when given a pull request URL", () => {
 		const url = "https://github.com/owner/repository/pull/123";
 
 		const { actor } = createActor(mockOctokit, url);
 
-		expect(actor).toBeInstanceOf(IssueLikeActor);
+		expect(actor).toBeInstanceOf(PullRequestActor);
 	});
 });

--- a/src/actors/createActor.ts
+++ b/src/actors/createActor.ts
@@ -2,9 +2,10 @@ import type { Octokit } from "octokit";
 
 import { DiscussionActor } from "./DiscussionActor.js";
 import { DiscussionCommentActor } from "./DiscussionCommentActor.js";
-import { IssueLikeActor } from "./IssueLikeActor.js";
+import { IssueActor } from "./IssueActor.js";
 import { IssueLikeCommentActor } from "./IssueLikeCommentActor.js";
 import { parseLocator } from "./parseLocator.js";
+import { PullRequestActor } from "./PullRequestActor.js";
 
 export function createActor(octokit: Octokit, url: string) {
 	const locator = parseLocator(url);
@@ -36,15 +37,19 @@ export function createActor(octokit: Octokit, url: string) {
 			case "issues":
 			case "pull": {
 				const parentType = urlType === "issues" ? "issue" : "pull_request";
-				return commentNumber
-					? new IssueLikeCommentActor(
-							+commentNumber,
-							locator,
-							octokit,
-							+parentNumber,
-							parentType,
-						)
-					: new IssueLikeActor(+parentNumber, parentType, locator, octokit);
+				if (commentNumber) {
+					return new IssueLikeCommentActor(
+						+commentNumber,
+						locator,
+						octokit,
+						+parentNumber,
+						parentType,
+					);
+				}
+
+				return parentType === "issue"
+					? new IssueActor(+parentNumber, parentType, locator, octokit)
+					: new PullRequestActor(+parentNumber, parentType, locator, octokit);
 			}
 		}
 	})();

--- a/src/runOctoGuideRules.ts
+++ b/src/runOctoGuideRules.ts
@@ -1,3 +1,4 @@
+import * as core from "@actions/core";
 import { octokitFromAuth } from "octokit-from-auth";
 
 import type { EntityActor } from "./actors/types.js";
@@ -76,6 +77,8 @@ export async function runOctoGuideRules({
 		data: await actor.getData(),
 		...actor.metadata,
 	} as Entity;
+	core.debug(`Full entity: ${JSON.stringify(entity, null, 2)}`);
+
 	const reports: RuleReport[] = [];
 
 	await Promise.all(


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #67
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/OctoGuide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/OctoGuide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Fixes a bug introduced by #43, that the general `IssueLikeActor` class was using the same `octokit.rest.issues.get` for both issues and PRs. `octokit.rest.pulls.get` is now used for PRs.

Also moves the `core.debug(Full entity: ...` from `runOctoGuideAction` to the start of `runOctoGuideRules`. That way it still gets logged if things crash.

🗺️  