### PR TITLE
fix: don't fail actions or write a summary on pass

### DIFF
--- a/src/action/comments/outputActionReports.test.ts
+++ b/src/action/comments/outputActionReports.test.ts
@@ -93,6 +93,8 @@ describe(outputActionReports, () => {
 			  ],
 			]
 		`);
+		expect(mockCore.summary.write).toHaveBeenCalled();
+		expect(mockCore.setFailed).toHaveBeenCalled();
 	});
 
 	it("logs info and not error when comment creation succeeds", async () => {
@@ -107,6 +109,8 @@ describe(outputActionReports, () => {
 			  ],
 			]
 		`);
+		expect(mockCore.summary.write).toHaveBeenCalled();
+		expect(mockCore.setFailed).toHaveBeenCalled();
 	});
 
 	it("logs the request error when comment creation fails with a 403 GitHub error", async () => {
@@ -127,7 +131,7 @@ describe(outputActionReports, () => {
 			  ],
 			]
 		`);
-		expect(mockConsole.error.mock.calls).toMatchInlineSnapshot(`[]`);
+		expect(mockConsole.error).not.toHaveBeenCalled();
 	});
 
 	it("logs the error as an error when comment creation fails with an unknown error", async () => {
@@ -149,5 +153,16 @@ describe(outputActionReports, () => {
 			  ],
 			]
 		`);
+		expect(mockCore.summary.write).toHaveBeenCalled();
+		expect(mockCore.setFailed).toHaveBeenCalled();
+	});
+
+	it("does not write an Actions summary when there are no reports", async () => {
+		mockSetCommentForReports.mockResolvedValueOnce(undefined);
+
+		await outputActionReports(actor, entity, []);
+
+		expect(mockCore.summary.write).not.toHaveBeenCalled();
+		expect(mockCore.setFailed).not.toHaveBeenCalled();
 	});
 });

--- a/src/action/comments/outputActionReports.ts
+++ b/src/action/comments/outputActionReports.ts
@@ -40,7 +40,9 @@ export async function outputActionReports(
 		}
 	}
 
-	await actionReporter(headline, reports, core.summary);
-	await core.summary.write();
-	core.setFailed(headline);
+	if (reports.length) {
+		await actionReporter(headline, reports, core.summary);
+		await core.summary.write();
+		core.setFailed(headline);
+	}
 }

--- a/src/reporters/actionReporter.test.ts
+++ b/src/reporters/actionReporter.test.ts
@@ -43,31 +43,6 @@ const summary = {
 } as unknown as Mocked<typeof core.summary>;
 
 describe(actionReporter, () => {
-	test("no reports", async () => {
-		await actionReporter(headline, [], summary);
-
-		expect(summary.addHeading.mock.calls).toMatchInlineSnapshot(`
-			[
-			  [
-			    "OctoGuide Report",
-			    1,
-			  ],
-			]
-		`);
-		expect(summary.addRaw.mock.calls).toMatchInlineSnapshot(`
-			[
-			  [
-			    "Hello, world!
-
-			",
-			  ],
-			  [
-			    "🗺️ <em>This message was posted automatically by <a href="https://github.com/JoshuaKGoldberg/OctoGuide">OctoGuide</a>: a bot for GitHub repository best practices.</em>",
-			  ],
-			]
-		`);
-	});
-
 	test("one report", async () => {
 		await actionReporter(
 			headline,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #88
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/OctoGuide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/OctoGuide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Skips calling `actionReporter` at all if there's no failure.

🗺️ 