### PR TITLE
fix: support all github pr template locations

### DIFF
--- a/src/action/findPrTemplate.test.ts
+++ b/src/action/findPrTemplate.test.ts
@@ -1,0 +1,119 @@
+import type { Octokit } from "octokit";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { RepositoryLocator } from "../types/data.js";
+
+import { findPrTemplate, PR_TEMPLATE_PATHS } from "./findPrTemplate";
+
+interface GetContentParams {
+	owner: string;
+	path: string;
+	repo: string;
+}
+
+describe("findPrTemplate", () => {
+	const mockLocator: RepositoryLocator = {
+		owner: "test-owner",
+		repository: "test-repo",
+	};
+	const mockTemplate = "# PR Template\n- [ ] Task 1\n- [ ] Task 2";
+	const mockBase64Template = Buffer.from(mockTemplate).toString("base64");
+
+	const getContentMock = vi.fn();
+	const mockOctokit = {
+		rest: {
+			repos: {
+				getContent: getContentMock,
+			},
+		},
+	} as unknown as Octokit;
+
+	beforeEach(() => {
+		vi.resetAllMocks();
+		getContentMock.mockRejectedValue(new Error("Not found"));
+	});
+
+	PR_TEMPLATE_PATHS.forEach((path) => {
+		it(`should find template at ${path}`, async () => {
+			getContentMock.mockImplementation((params: GetContentParams) => {
+				if (params.path === path) {
+					return Promise.resolve({
+						data: {
+							content: mockBase64Template,
+							type: "file",
+						},
+					});
+				}
+				return Promise.reject(new Error("Not found"));
+			});
+
+			const result = await findPrTemplate(mockOctokit, mockLocator);
+
+			expect(result).toBe(mockTemplate);
+			expect(getContentMock).toHaveBeenCalledWith({
+				owner: mockLocator.owner,
+				path,
+				repo: mockLocator.repository,
+			});
+		});
+	});
+
+	it("should find template in .github/PULL_REQUEST_TEMPLATE directory", async () => {
+		getContentMock.mockImplementation((params: GetContentParams) => {
+			if (params.path === ".github/PULL_REQUEST_TEMPLATE") {
+				return Promise.resolve({
+					data: [
+						{
+							name: "template.md",
+							path: ".github/PULL_REQUEST_TEMPLATE/template.md",
+							type: "file",
+						},
+						{
+							name: "other.txt",
+							path: ".github/PULL_REQUEST_TEMPLATE/other.txt",
+							type: "file",
+						},
+					],
+				});
+			} else if (params.path === ".github/PULL_REQUEST_TEMPLATE/template.md") {
+				return Promise.resolve({
+					data: {
+						content: mockBase64Template,
+						type: "file",
+					},
+				});
+			}
+			return Promise.reject(new Error("Not found"));
+		});
+
+		const result = await findPrTemplate(mockOctokit, mockLocator);
+
+		expect(result).toBe(mockTemplate);
+		expect(getContentMock).toHaveBeenCalledWith({
+			owner: mockLocator.owner,
+			path: ".github/PULL_REQUEST_TEMPLATE",
+			repo: mockLocator.repository,
+		});
+		expect(getContentMock).toHaveBeenCalledWith({
+			owner: mockLocator.owner,
+			path: ".github/PULL_REQUEST_TEMPLATE/template.md",
+			repo: mockLocator.repository,
+		});
+	});
+
+	it("should return null if no template is found", async () => {
+		const result = await findPrTemplate(mockOctokit, mockLocator);
+
+		expect(result).toBeNull();
+		expect(getContentMock).toHaveBeenCalledTimes(PR_TEMPLATE_PATHS.length + 1);
+	});
+
+	it("should handle API errors gracefully", async () => {
+		getContentMock.mockRejectedValue(new Error("API Error"));
+
+		const result = await findPrTemplate(mockOctokit, mockLocator);
+
+		expect(result).toBeNull();
+	});
+});

--- a/src/action/findPrTemplate.ts
+++ b/src/action/findPrTemplate.ts
@@ -1,0 +1,76 @@
+import type { Octokit } from "octokit";
+
+import type { RepositoryLocator } from "../types/data.js";
+
+import { wrapSafe } from "../types/utils.js";
+
+/**
+ * Paths where GitHub PR templates might be located according to GitHub documentation
+ * @see https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository
+ */
+export const PR_TEMPLATE_PATHS = [
+	".github/PULL_REQUEST_TEMPLATE.md",
+	".github/pull_request_template.md",
+	"docs/PULL_REQUEST_TEMPLATE.md",
+	"docs/pull_request_template.md",
+];
+
+export async function findPrTemplate(
+	octokit: Octokit,
+	locator: RepositoryLocator,
+): Promise<null | string> {
+	for (const path of PR_TEMPLATE_PATHS) {
+		const response = await wrapSafe(
+			octokit.rest.repos.getContent({
+				owner: locator.owner,
+				path,
+				repo: locator.repository,
+			}),
+		);
+
+		if (
+			response &&
+			!Array.isArray(response.data) &&
+			response.data.type === "file"
+		) {
+			return Buffer.from(response.data.content, "base64").toString("utf-8");
+		}
+	}
+
+	const templateDirPath = ".github/PULL_REQUEST_TEMPLATE";
+	const dirResponse = await wrapSafe(
+		octokit.rest.repos.getContent({
+			owner: locator.owner,
+			path: templateDirPath,
+			repo: locator.repository,
+		}),
+	);
+
+	if (dirResponse && Array.isArray(dirResponse.data)) {
+		const templateFile = dirResponse.data.find(
+			(file) => file.type === "file" && file.name.endsWith(".md"),
+		);
+
+		if (templateFile?.path) {
+			const fileResponse = await wrapSafe(
+				octokit.rest.repos.getContent({
+					owner: locator.owner,
+					path: templateFile.path,
+					repo: locator.repository,
+				}),
+			);
+
+			if (
+				fileResponse &&
+				!Array.isArray(fileResponse.data) &&
+				fileResponse.data.type === "file"
+			) {
+				return Buffer.from(fileResponse.data.content, "base64").toString(
+					"utf-8",
+				);
+			}
+		}
+	}
+
+	return null;
+}

--- a/src/rules/prBodyNotEmpty.ts
+++ b/src/rules/prBodyNotEmpty.ts
@@ -1,4 +1,4 @@
-import { wrapSafe } from "../types/utils.js";
+import { findPrTemplate } from "../action/findPrTemplate.js";
 import { defineRule } from "./defineRule.js";
 
 export const prBodyNotEmpty = defineRule({
@@ -22,19 +22,9 @@ export const prBodyNotEmpty = defineRule({
 			return;
 		}
 
-		const templateResponse = await wrapSafe(
-			context.octokit.rest.repos.getContent({
-				owner: context.locator.owner,
-				path: ".github/PULL_REQUEST_TEMPLATE.md",
-				repo: context.locator.repository,
-			}),
-		);
+		const template = await findPrTemplate(context.octokit, context.locator);
 
-		if (
-			!templateResponse ||
-			Array.isArray(templateResponse.data) ||
-			templateResponse.data.type !== "file"
-		) {
+		if (!template) {
 			if (
 				entity.data.body
 					.trim()
@@ -50,11 +40,6 @@ export const prBodyNotEmpty = defineRule({
 			}
 			return;
 		}
-
-		const template = Buffer.from(
-			templateResponse.data.content,
-			"base64",
-		).toString("utf-8");
 
 		const templateWords = new Set(
 			template.toLowerCase().match(/[\p{L}\p{N}]+/gu) ?? [],

--- a/src/rules/prTaskCompletion.ts
+++ b/src/rules/prTaskCompletion.ts
@@ -1,4 +1,4 @@
-import { wrapSafe } from "../types/utils.js";
+import { findPrTemplate } from "../action/findPrTemplate.js";
 import { defineRule } from "./defineRule.js";
 
 export const prTaskCompletion = defineRule({
@@ -13,26 +13,11 @@ export const prTaskCompletion = defineRule({
 		name: "pr-task-completion",
 	},
 	async pullRequest(context, entity) {
-		const templateResponse = await wrapSafe(
-			context.octokit.rest.repos.getContent({
-				owner: context.locator.owner,
-				path: ".github/PULL_REQUEST_TEMPLATE.md",
-				repo: context.locator.repository,
-			}),
-		);
+		const template = await findPrTemplate(context.octokit, context.locator);
 
-		if (
-			!templateResponse ||
-			Array.isArray(templateResponse.data) ||
-			templateResponse.data.type !== "file"
-		) {
+		if (!template) {
 			return;
 		}
-
-		const template = Buffer.from(
-			templateResponse.data.content,
-			"base64",
-		).toString("utf-8");
 		const templateTasks = Array.from(
 			template.matchAll(/[-*]\s*\[\s*\]\s*(.+)/g),
 		);


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #47
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/OctoGuide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/OctoGuide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

The current implementation of `prTaskCompletion` and `prBodyNotEmpty` rules only checks for PR templates in one specific location (`.github/PULL_REQUEST_TEMPLATE.md`). This leads to false positives when a template exists but is located in another valid location.

Created a universal `findPrTemplate` function that checks for PR templates in all possible locations according to [GitHub documentation](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository):

- `.github/PULL_REQUEST_TEMPLATE.md` (uppercase)
- `.github/pull_request_template.md` (lowercase)
- `.github/PULL_REQUEST_TEMPLATE/` (directory with templates)
- `docs/PULL_REQUEST_TEMPLATE.md`
- `docs/pull_request_template.md`

Updated `prTaskCompletion` and `prBodyNotEmpty` rules to use this function, ensuring correct behavior with any valid PR template location.
