### PR TITLE
docs: generate rules table automatically

### DIFF
--- a/site/src/components/RulesTable.astro
+++ b/site/src/components/RulesTable.astro
@@ -1,0 +1,98 @@
+---
+import { marked } from "marked";
+
+import { allRules } from "../../../src/rules/all.js";
+import type { Rule } from "../../../src/types/rules.js";
+
+const configEmojis = {
+	recommended: "✅",
+	strict: "🔒",
+};
+
+function getRuleArea(rule: Rule) {
+	switch (rule.about.name.split("-")[0]) {
+		case "comment":
+			return "Comments";
+		case "pr":
+			return "PRs";
+		case "issue":
+			return "Issues";
+		default:
+			return "Text";
+	}
+}
+
+async function getRuleDescription(rule: Rule) {
+	return await marked.parseInline(
+		rule.about.description
+			.replace(/(?:comment|pr|pr)s?/i, "")
+			.replace(/\.$/, "")
+			.toLowerCase(),
+	);
+}
+---
+
+<div>Config key:</div>
+
+<dl id="config-key-dl">
+	<dt>✅</dt><dd>Recommended</dd>
+	<dt>🔒</dt><dd>Strict</dd>
+</dl>
+
+<table aria-describedby="config-key-dl">
+	<thead>
+		<tr>
+			<th>Area</th>
+			<th>OctoGuide Rule</th>
+			<th>Entity Description</th>
+			<th>Config</th>
+		</tr>
+	</thead>
+	<tbody>
+		{
+			allRules.map(async (rule) => (
+				<tr>
+					<td>{getRuleArea(rule)}</td>
+					<td>
+						<a href={`/rules/{rule.about.name}`}>{rule.about.name}</a>
+					</td>
+					<td>
+						<Fragment set:html={await getRuleDescription(rule)} />
+					</td>
+					<td>{configEmojis[rule.about.config]}</td>
+				</tr>
+			))
+		}
+	</tbody>
+</table>
+
+<style>
+	dl {
+		display: inline-grid;
+		grid-template-columns: auto 1fr;
+		grid-template-rows: auto auto;
+	}
+
+	dt {
+		display: list-item;
+		list-style-type: disc;
+		margin-inline-start: 2.5rem;
+		padding-inline-start: 0;
+		margin-top: 0;
+	}
+
+	dt::after {
+		content: ": ";
+		margin-right: 0.5rem;
+	}
+
+	dd,
+	dt {
+		margin-top: 0;
+	}
+
+	dd {
+		display: inline;
+		padding-inline-start: 0;
+	}
+</style>

--- a/site/src/content/docs/configs.mdx
+++ b/site/src/content/docs/configs.mdx
@@ -2,6 +2,8 @@
 title: Preset Configs
 ---
 
+import RulesTable from "../../components/RulesTable.astro";
+
 OctoGuide provides two starting preset "configs", or lists of rules:
 
 - **recommended** _(default)_: Rules that apply to almost every open source GitHub repository
@@ -11,17 +13,4 @@ See [Configuration > `config`](./get-started#configuration) for how to specify a
 
 ## Rules Table
 
-Config key:
-
-- ✅: Recommended
-- 🔒: Strict
-
-| Area     | OctoGuide Rule                                         | Entity Requirement                          | Config |
-| -------- | ------------------------------------------------------ | ------------------------------------------- | ------ |
-| Comments | [comment-meaningless](./rules/comment-meaningless)     | should be meaningful, not just '+1' bumps   | ✅     |
-| PRs      | [pr-branch-non-default](./rules/pr-branch-non-default) | must be sent from a non-default branch      | ✅     |
-| PRs      | [pr-body-not-empty](./rules/pr-body-not-empty)         | have a description beyond the template      | ✅     |
-| PRs      | [pr-linked-issue](./rules/pr-linked-issue)             | must be linked to an issue                  | 🔒     |
-| PRs      | [pr-task-completion](./rules/pr-task-completion)       | all required tasks are [x] completed        | ✅     |
-| PRs      | [pr-title-conventional](./rules/pr-title-conventional) | title must be in conventional commit format | 🔒     |
-| Text     | [text-image-alt-text](./rules/text-image-alt-text)     | images must have accessible alt text        | ✅     |
+<RulesTable />

--- a/src/rules/prBranchNonDefault.ts
+++ b/src/rules/prBranchNonDefault.ts
@@ -3,8 +3,7 @@ import { defineRule } from "./defineRule.js";
 export const prBranchNonDefault = defineRule({
 	about: {
 		config: "recommended",
-		description:
-			"PRs should not be sent from their head repository's default branch.",
+		description: "PRs should be sent from a non-default branch.",
 		explanation: [
 			`Sending a PR from a repository's default branch, commonly \`main\`, means that repository will have a hard time pulling in updates from the upstream repository.`,
 			`It's generally recommended to instead create a new branch per pull request.`,

--- a/src/rules/prTaskCompletion.ts
+++ b/src/rules/prTaskCompletion.ts
@@ -4,8 +4,7 @@ import { defineRule } from "./defineRule.js";
 export const prTaskCompletion = defineRule({
 	about: {
 		config: "recommended",
-		description:
-			"Tasks lists from the pull request template should be `[x]` filled out.",
+		description: "Tasks from the template should be `[x]` filled out.",
 		explanation: [
 			`Repositories often provide a set of tasks that pull request authors are expected to complete.`,
 			`Those tasks should be marked as completed with a \`[x]\` in the pull request description.`,


### PR DESCRIPTION
## PR Checklist

- [x] Addresses an existing open issue: fixes #65
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/OctoGuide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/OctoGuide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

Shrinks the `about.description`s of a couple rules so their table row doesn't wrap onto a second line in common viewports.

🗺️ 