### PR TITLE
feat: configure comment-header and comment-footer

### DIFF
--- a/site/src/content/docs/get-started.mdx
+++ b/site/src/content/docs/get-started.mdx
@@ -4,7 +4,11 @@ title: Get Started
 
 import { Code } from "@astrojs/starlight/components";
 
-import { getStartedBase, getStartedStrict } from "../../data/yml.js";
+import {
+	getStartedBase,
+	getStartedStrict,
+	getStartedFooter,
+} from "../../data/yml.js";
 
 OctoGuide checks that contributor activity on your GitHub repository aligns with common expectations of smoothly-running projects.
 It will automatically post friendly comments when contributors take actions you don't want them to.
@@ -57,3 +61,18 @@ For public repositories that's the following permissions:
 
 - `repo` > `public_repo`
 - `read:discussion`
+
+### `comment-footer`
+
+You can customize the footer message that OctoGuide adds to its comments by providing a `comment-footer` input as a string.
+
+**Example:**
+
+<Code
+	code={getStartedFooter}
+	meta="lang=yml"
+	lang="diff"
+	title=".github/workflows/octoguide.yml"
+/>
+
+If no custom footer is provided, OctoGuide uses its default message.

--- a/site/src/content/docs/get-started.mdx
+++ b/site/src/content/docs/get-started.mdx
@@ -7,6 +7,7 @@ import { Code } from "@astrojs/starlight/components";
 import {
 	getStartedBase,
 	getStartedStrict,
+	getStartedHeader,
 	getStartedFooter,
 } from "../../data/yml.js";
 
@@ -61,6 +62,21 @@ For public repositories that's the following permissions:
 
 - `repo` > `public_repo`
 - `read:discussion`
+
+### `comment-header`
+
+You can customize the header message that OctoGuide adds to its comments by providing a `comment-header` input as a string.
+
+**Example:**
+
+<Code
+	code={getStartedHeader}
+	meta="lang=yml"
+	lang="diff"
+	title=".github/workflows/octoguide.yml"
+/>
+
+If no custom header is provided, OctoGuide uses its default message.
 
 ### `comment-footer`
 

--- a/site/src/content/docs/get-started.mdx
+++ b/site/src/content/docs/get-started.mdx
@@ -76,7 +76,7 @@ You can customize the header message that OctoGuide adds to its comments by prov
 	title=".github/workflows/octoguide.yml"
 />
 
-If no custom header is provided, OctoGuide uses its default message.
+If no custom header is provided, OctoGuide by default has no header message.
 
 ### `comment-footer`
 

--- a/site/src/data/yml.ts
+++ b/site/src/data/yml.ts
@@ -42,3 +42,11 @@ jobs:
         with:
 +          config: strict
           github-token: \${{ secrets.GITHUB_TOKEN }}`;
+
+export const getStartedFooter = `jobs:
+  octoguide:
+    steps:
+      - uses: JoshuaKGoldberg/octoguide@v0
+        with:
++          comment-footer: "🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices."
+          github-token: \${{ secrets.GITHUB_TOKEN }}`;

--- a/site/src/data/yml.ts
+++ b/site/src/data/yml.ts
@@ -43,8 +43,20 @@ jobs:
 +          config: strict
           github-token: \${{ secrets.GITHUB_TOKEN }}`;
 
+export const getStartedHeader = `jobs:
+  octoguide:
+    if: \${{ !endsWith(github.actor, '[bot]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JoshuaKGoldberg/octoguide${atVersion}
+        with:
++          comment-header: "Hey! You! Listen! This is a bot message from Octoguide! 🐙"
+          github-token: \${{ secrets.GITHUB_TOKEN }}`;
+
 export const getStartedFooter = `jobs:
   octoguide:
+    if: \${{ !endsWith(github.actor, '[bot]') }}
+    runs-on: ubuntu-latest
     steps:
       - uses: JoshuaKGoldberg/octoguide@v0
         with:

--- a/src/action/comments/createCommentBody.ts
+++ b/src/action/comments/createCommentBody.ts
@@ -1,17 +1,19 @@
-import type { CommentConfig } from "../../types/commentConfig.js";
 import type { Entity } from "../../types/entities.js";
+import type { Settings } from "../../types/settings.js";
 
 import { createCommentIdentifier } from "./createCommentIdentifier.js";
 
 export function createCommentBody(
 	entity: Entity,
 	message: string,
-	commentConfig: CommentConfig,
+	settings: Settings,
 ): string {
 	return [
-		`## ${commentConfig.header}`,
+		settings.comments.header && `## ${settings.comments.header}`,
 		message,
-		`> _${commentConfig.footer}_`,
+		settings.comments.footer && `> _${settings.comments.footer}_`,
 		createCommentIdentifier(entity.data.html_url),
-	].join("\n\n");
+	]
+		.filter(Boolean)
+		.join("\n\n");
 }

--- a/src/action/comments/createCommentBody.ts
+++ b/src/action/comments/createCommentBody.ts
@@ -1,3 +1,4 @@
+import type { CommentConfig } from "../../types/commentConfig.js";
 import type { Entity } from "../../types/entities.js";
 
 import { createCommentIdentifier } from "./createCommentIdentifier.js";
@@ -5,11 +6,12 @@ import { createCommentIdentifier } from "./createCommentIdentifier.js";
 export function createCommentBody(
 	entity: Entity,
 	message: string,
-	footer: string,
+	commentConfig: CommentConfig,
 ): string {
 	return [
+		`## ${commentConfig.header}`,
 		message,
-		`> _${footer}_`,
+		`> _${commentConfig.footer}_`,
 		createCommentIdentifier(entity.data.html_url),
 	].join("\n\n");
 }

--- a/src/action/comments/createCommentBody.ts
+++ b/src/action/comments/createCommentBody.ts
@@ -2,10 +2,14 @@ import type { Entity } from "../../types/entities.js";
 
 import { createCommentIdentifier } from "./createCommentIdentifier.js";
 
-export function createCommentBody(entity: Entity, message: string): string {
+export function createCommentBody(
+	entity: Entity,
+	message: string,
+	footer: string,
+): string {
 	return [
 		message,
-		`> 🗺️ _This message was posted automatically by [OctoGuide](https://github.com/JoshuaKGoldberg/OctoGuide): a bot for GitHub repository best practices._`,
+		`> _${footer}_`,
 		createCommentIdentifier(entity.data.html_url),
 	].join("\n\n");
 }

--- a/src/action/comments/createNewCommentForReports.test.ts
+++ b/src/action/comments/createNewCommentForReports.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { EntityActor } from "../../actors/types.js";
-import type { CommentConfig } from "../../types/commentConfig.js";
 import type { CommentEntity, DiscussionEntity } from "../../types/entities.js";
+import type { Settings } from "../../types/settings.js";
 
 import { createCommentBody } from "./createCommentBody.js";
 import { createNewCommentForReports } from "./createNewCommentForReports.js";
@@ -24,10 +24,12 @@ const entityActor = {
 	createComment: mockCreateComment,
 } as unknown as EntityActor;
 
-const commentConfig = {
-	footer: "Test footer",
-	header: "Test header",
-} satisfies CommentConfig;
+const settings = {
+	comments: {
+		footer: "Test footer",
+		header: "Test header",
+	},
+} satisfies Settings;
 
 describe(createNewCommentForReports, () => {
 	it("targets the parent number when the entity is a comment", async () => {
@@ -41,15 +43,10 @@ describe(createNewCommentForReports, () => {
 			type: "comment",
 		} as CommentEntity;
 
-		await createNewCommentForReports(
-			entityActor,
-			entity,
-			reported,
-			commentConfig,
-		);
+		await createNewCommentForReports(entityActor, entity, reported, settings);
 
 		expect(mockCreateComment).toHaveBeenCalledWith(
-			createCommentBody(entity, reported, commentConfig),
+			createCommentBody(entity, reported, settings),
 		);
 		expect(mockCore.info).toHaveBeenCalledWith(
 			`Target number for comment creation: ${parentNumber.toString()}`,
@@ -67,15 +64,10 @@ describe(createNewCommentForReports, () => {
 			type: "discussion",
 		} as DiscussionEntity;
 
-		await createNewCommentForReports(
-			entityActor,
-			entity,
-			reported,
-			commentConfig,
-		);
+		await createNewCommentForReports(entityActor, entity, reported, settings);
 
 		expect(mockCreateComment).toHaveBeenCalledWith(
-			createCommentBody(entity, reported, commentConfig),
+			createCommentBody(entity, reported, settings),
 		);
 		expect(mockCore.info).toHaveBeenCalledWith(
 			`Target number for comment creation: ${number.toString()}`,

--- a/src/action/comments/createNewCommentForReports.test.ts
+++ b/src/action/comments/createNewCommentForReports.test.ts
@@ -24,6 +24,8 @@ const entityActor = {
 } as unknown as EntityActor;
 
 describe(createNewCommentForReports, () => {
+	const commentFooter = "Test footer";
+
 	it("targets the parent number when the entity is a comment", async () => {
 		const parentNumber = 123;
 
@@ -35,10 +37,15 @@ describe(createNewCommentForReports, () => {
 			type: "comment",
 		} as CommentEntity;
 
-		await createNewCommentForReports(entityActor, entity, reported);
+		await createNewCommentForReports(
+			entityActor,
+			entity,
+			reported,
+			commentFooter,
+		);
 
 		expect(mockCreateComment).toHaveBeenCalledWith(
-			createCommentBody(entity, reported),
+			createCommentBody(entity, reported, commentFooter),
 		);
 		expect(mockCore.info).toHaveBeenCalledWith(
 			`Target number for comment creation: ${parentNumber.toString()}`,
@@ -56,10 +63,15 @@ describe(createNewCommentForReports, () => {
 			type: "discussion",
 		} as DiscussionEntity;
 
-		await createNewCommentForReports(entityActor, entity, reported);
+		await createNewCommentForReports(
+			entityActor,
+			entity,
+			reported,
+			commentFooter,
+		);
 
 		expect(mockCreateComment).toHaveBeenCalledWith(
-			createCommentBody(entity, reported),
+			createCommentBody(entity, reported, commentFooter),
 		);
 		expect(mockCore.info).toHaveBeenCalledWith(
 			`Target number for comment creation: ${number.toString()}`,

--- a/src/action/comments/createNewCommentForReports.test.ts
+++ b/src/action/comments/createNewCommentForReports.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { EntityActor } from "../../actors/types.js";
+import type { CommentConfig } from "../../types/commentConfig.js";
 import type { CommentEntity, DiscussionEntity } from "../../types/entities.js";
 
 import { createCommentBody } from "./createCommentBody.js";
@@ -23,9 +24,12 @@ const entityActor = {
 	createComment: mockCreateComment,
 } as unknown as EntityActor;
 
-describe(createNewCommentForReports, () => {
-	const commentFooter = "Test footer";
+const commentConfig = {
+	footer: "Test footer",
+	header: "Test header",
+} as CommentConfig;
 
+describe(createNewCommentForReports, () => {
 	it("targets the parent number when the entity is a comment", async () => {
 		const parentNumber = 123;
 
@@ -41,11 +45,11 @@ describe(createNewCommentForReports, () => {
 			entityActor,
 			entity,
 			reported,
-			commentFooter,
+			commentConfig,
 		);
 
 		expect(mockCreateComment).toHaveBeenCalledWith(
-			createCommentBody(entity, reported, commentFooter),
+			createCommentBody(entity, reported, commentConfig),
 		);
 		expect(mockCore.info).toHaveBeenCalledWith(
 			`Target number for comment creation: ${parentNumber.toString()}`,
@@ -67,11 +71,11 @@ describe(createNewCommentForReports, () => {
 			entityActor,
 			entity,
 			reported,
-			commentFooter,
+			commentConfig,
 		);
 
 		expect(mockCreateComment).toHaveBeenCalledWith(
-			createCommentBody(entity, reported, commentFooter),
+			createCommentBody(entity, reported, commentConfig),
 		);
 		expect(mockCore.info).toHaveBeenCalledWith(
 			`Target number for comment creation: ${number.toString()}`,

--- a/src/action/comments/createNewCommentForReports.test.ts
+++ b/src/action/comments/createNewCommentForReports.test.ts
@@ -27,7 +27,7 @@ const entityActor = {
 const commentConfig = {
 	footer: "Test footer",
 	header: "Test header",
-} as CommentConfig;
+} satisfies CommentConfig;
 
 describe(createNewCommentForReports, () => {
 	it("targets the parent number when the entity is a comment", async () => {

--- a/src/action/comments/createNewCommentForReports.ts
+++ b/src/action/comments/createNewCommentForReports.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 
 import type { EntityActor } from "../../actors/types.js";
+import type { CommentConfig } from "../../types/commentConfig.js";
 import type { Entity } from "../../types/entities.js";
 
 import { createCommentBody } from "./createCommentBody.js";
@@ -9,13 +10,13 @@ export async function createNewCommentForReports(
 	actor: EntityActor,
 	entity: Entity,
 	reported: string,
-	commentFooter: string,
+	commentConfig: CommentConfig,
 ) {
 	const targetNumber =
 		entity.type === "comment" ? entity.parentNumber : entity.number;
 	core.info(`Target number for comment creation: ${targetNumber.toString()}`);
 
 	return await actor.createComment(
-		createCommentBody(entity, reported, commentFooter),
+		createCommentBody(entity, reported, commentConfig),
 	);
 }

--- a/src/action/comments/createNewCommentForReports.ts
+++ b/src/action/comments/createNewCommentForReports.ts
@@ -9,10 +9,13 @@ export async function createNewCommentForReports(
 	actor: EntityActor,
 	entity: Entity,
 	reported: string,
+	commentFooter: string,
 ) {
 	const targetNumber =
 		entity.type === "comment" ? entity.parentNumber : entity.number;
 	core.info(`Target number for comment creation: ${targetNumber.toString()}`);
 
-	return await actor.createComment(createCommentBody(entity, reported));
+	return await actor.createComment(
+		createCommentBody(entity, reported, commentFooter),
+	);
 }

--- a/src/action/comments/createNewCommentForReports.ts
+++ b/src/action/comments/createNewCommentForReports.ts
@@ -1,8 +1,8 @@
 import * as core from "@actions/core";
 
 import type { EntityActor } from "../../actors/types.js";
-import type { CommentConfig } from "../../types/commentConfig.js";
 import type { Entity } from "../../types/entities.js";
+import type { Settings } from "../../types/settings.js";
 
 import { createCommentBody } from "./createCommentBody.js";
 
@@ -10,13 +10,13 @@ export async function createNewCommentForReports(
 	actor: EntityActor,
 	entity: Entity,
 	reported: string,
-	commentConfig: CommentConfig,
+	settings: Settings,
 ) {
 	const targetNumber =
 		entity.type === "comment" ? entity.parentNumber : entity.number;
 	core.info(`Target number for comment creation: ${targetNumber.toString()}`);
 
 	return await actor.createComment(
-		createCommentBody(entity, reported, commentConfig),
+		createCommentBody(entity, reported, settings),
 	);
 }

--- a/src/action/comments/outputActionReports.test.ts
+++ b/src/action/comments/outputActionReports.test.ts
@@ -1,10 +1,10 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EntityActor } from "../../actors/types.js";
-import type { CommentConfig } from "../../types/commentConfig.js";
 import type { IssueEntity } from "../../types/entities.js";
 import type { RuleReport, RuleReportData } from "../../types/reports.js";
 import type { RuleAboutWithUrl } from "../../types/rules.js";
+import type { Settings } from "../../types/settings.js";
 
 import { outputActionReports } from "./outputActionReports.js";
 
@@ -76,10 +76,12 @@ const mockConsole = {
 	error: vi.fn(),
 	info: vi.fn(),
 };
-const commentConfig = {
-	footer: "Test footer",
-	header: "Test header",
-} satisfies CommentConfig;
+const settings = {
+	comments: {
+		footer: "Test footer",
+		header: "Test header",
+	},
+} satisfies Settings;
 
 describe(outputActionReports, () => {
 	beforeEach(() => {
@@ -89,7 +91,7 @@ describe(outputActionReports, () => {
 	it("logs info and not error when no comment is created, successfully", async () => {
 		mockSetCommentForReports.mockResolvedValueOnce(undefined);
 
-		await outputActionReports(actor, entity, reports, commentConfig);
+		await outputActionReports(actor, entity, reports, settings);
 
 		expect(mockCore.info.mock.calls).toMatchInlineSnapshot(`
 			[
@@ -105,7 +107,7 @@ describe(outputActionReports, () => {
 	it("logs info and not error when comment creation succeeds", async () => {
 		mockSetCommentForReports.mockResolvedValueOnce(fakeComment);
 
-		await outputActionReports(actor, entity, reports, commentConfig);
+		await outputActionReports(actor, entity, reports, settings);
 
 		expect(mockCore.info.mock.calls).toMatchInlineSnapshot(`
 			[
@@ -124,7 +126,7 @@ describe(outputActionReports, () => {
 			status: 403,
 		});
 
-		await outputActionReports(actor, entity, reports, commentConfig);
+		await outputActionReports(actor, entity, reports, settings);
 
 		expect(mockCore.info.mock.calls).toMatchInlineSnapshot(`
 			[
@@ -142,7 +144,7 @@ describe(outputActionReports, () => {
 	it("logs the error as an error when comment creation fails with an unknown error", async () => {
 		mockSetCommentForReports.mockRejectedValueOnce(new Error("Oh no!"));
 
-		await outputActionReports(actor, entity, reports, commentConfig);
+		await outputActionReports(actor, entity, reports, settings);
 
 		expect(mockCore.info.mock.calls).toMatchInlineSnapshot(`
 			[
@@ -165,7 +167,7 @@ describe(outputActionReports, () => {
 	it("does not write an Actions summary when there are no reports", async () => {
 		mockSetCommentForReports.mockResolvedValueOnce(undefined);
 
-		await outputActionReports(actor, entity, [], commentConfig);
+		await outputActionReports(actor, entity, [], settings);
 
 		expect(mockCore.summary.write).not.toHaveBeenCalled();
 		expect(mockCore.setFailed).not.toHaveBeenCalled();

--- a/src/action/comments/outputActionReports.test.ts
+++ b/src/action/comments/outputActionReports.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { EntityActor } from "../../actors/types.js";
+import type { CommentConfig } from "../../types/commentConfig.js";
 import type { IssueEntity } from "../../types/entities.js";
 import type { RuleReport, RuleReportData } from "../../types/reports.js";
 import type { RuleAboutWithUrl } from "../../types/rules.js";
@@ -75,6 +76,10 @@ const mockConsole = {
 	error: vi.fn(),
 	info: vi.fn(),
 };
+const commentConfig = {
+	footer: "Test footer",
+	header: "Test header",
+} satisfies CommentConfig;
 
 describe(outputActionReports, () => {
 	beforeEach(() => {
@@ -84,7 +89,7 @@ describe(outputActionReports, () => {
 	it("logs info and not error when no comment is created, successfully", async () => {
 		mockSetCommentForReports.mockResolvedValueOnce(undefined);
 
-		await outputActionReports(actor, entity, reports);
+		await outputActionReports(actor, entity, reports, commentConfig);
 
 		expect(mockCore.info.mock.calls).toMatchInlineSnapshot(`
 			[
@@ -100,7 +105,7 @@ describe(outputActionReports, () => {
 	it("logs info and not error when comment creation succeeds", async () => {
 		mockSetCommentForReports.mockResolvedValueOnce(fakeComment);
 
-		await outputActionReports(actor, entity, reports);
+		await outputActionReports(actor, entity, reports, commentConfig);
 
 		expect(mockCore.info.mock.calls).toMatchInlineSnapshot(`
 			[
@@ -119,7 +124,7 @@ describe(outputActionReports, () => {
 			status: 403,
 		});
 
-		await outputActionReports(actor, entity, reports);
+		await outputActionReports(actor, entity, reports, commentConfig);
 
 		expect(mockCore.info.mock.calls).toMatchInlineSnapshot(`
 			[
@@ -137,7 +142,7 @@ describe(outputActionReports, () => {
 	it("logs the error as an error when comment creation fails with an unknown error", async () => {
 		mockSetCommentForReports.mockRejectedValueOnce(new Error("Oh no!"));
 
-		await outputActionReports(actor, entity, reports);
+		await outputActionReports(actor, entity, reports, commentConfig);
 
 		expect(mockCore.info.mock.calls).toMatchInlineSnapshot(`
 			[
@@ -160,7 +165,7 @@ describe(outputActionReports, () => {
 	it("does not write an Actions summary when there are no reports", async () => {
 		mockSetCommentForReports.mockResolvedValueOnce(undefined);
 
-		await outputActionReports(actor, entity, []);
+		await outputActionReports(actor, entity, [], commentConfig);
 
 		expect(mockCore.summary.write).not.toHaveBeenCalled();
 		expect(mockCore.setFailed).not.toHaveBeenCalled();

--- a/src/action/comments/outputActionReports.ts
+++ b/src/action/comments/outputActionReports.ts
@@ -14,12 +14,18 @@ export async function outputActionReports(
 	actor: EntityActor,
 	entity: Entity,
 	reports: RuleReport[],
+	commentFooter: string,
 ) {
 	const headline = createHeadlineAsMarkdown(entity, reports);
 	const reported = markdownReporter(headline, reports);
 
 	try {
-		const comment = await setCommentForReports(actor, entity, reported);
+		const comment = await setCommentForReports(
+			actor,
+			entity,
+			reported,
+			commentFooter,
+		);
 
 		core.info(
 			comment

--- a/src/action/comments/outputActionReports.ts
+++ b/src/action/comments/outputActionReports.ts
@@ -1,6 +1,7 @@
 import * as core from "@actions/core";
 
 import type { EntityActor } from "../../actors/types.js";
+import type { CommentConfig } from "../../types/commentConfig.js";
 import type { Entity } from "../../types/entities.js";
 import type { RuleReport } from "../../types/reports.js";
 
@@ -14,7 +15,7 @@ export async function outputActionReports(
 	actor: EntityActor,
 	entity: Entity,
 	reports: RuleReport[],
-	commentFooter: string,
+	commentConfig: CommentConfig,
 ) {
 	const headline = createHeadlineAsMarkdown(entity, reports);
 	const reported = markdownReporter(headline, reports);
@@ -24,7 +25,7 @@ export async function outputActionReports(
 			actor,
 			entity,
 			reported,
-			commentFooter,
+			commentConfig,
 		);
 
 		core.info(

--- a/src/action/comments/outputActionReports.ts
+++ b/src/action/comments/outputActionReports.ts
@@ -1,9 +1,9 @@
 import * as core from "@actions/core";
 
 import type { EntityActor } from "../../actors/types.js";
-import type { CommentConfig } from "../../types/commentConfig.js";
 import type { Entity } from "../../types/entities.js";
 import type { RuleReport } from "../../types/reports.js";
+import type { Settings } from "../../types/settings.js";
 
 import { actionReporter } from "../../reporters/actionReporter.js";
 import { createHeadlineAsMarkdown } from "../../reporters/createHeadlineAsMarkdown.js";
@@ -15,7 +15,7 @@ export async function outputActionReports(
 	actor: EntityActor,
 	entity: Entity,
 	reports: RuleReport[],
-	commentConfig: CommentConfig,
+	settings: Settings,
 ) {
 	const headline = createHeadlineAsMarkdown(entity, reports);
 	const reported = markdownReporter(headline, reports);
@@ -25,7 +25,7 @@ export async function outputActionReports(
 			actor,
 			entity,
 			reported,
-			commentConfig,
+			settings,
 		);
 
 		core.info(

--- a/src/action/comments/setCommentForReports.test.ts
+++ b/src/action/comments/setCommentForReports.test.ts
@@ -65,6 +65,8 @@ const existingComment = {
 const reportFail = "Oh no!";
 
 describe(setCommentForReports, () => {
+	const commentFooter = "Test footer";
+
 	it("returns without setting anything when the report is a pass and there is no existing comment", async () => {
 		mockGetExistingComment.mockResolvedValueOnce(undefined);
 
@@ -72,6 +74,7 @@ describe(setCommentForReports, () => {
 			actor,
 			entity,
 			markdownReportPassMessage,
+			commentFooter,
 		);
 
 		expect(mockUpdateExistingCommentForReports).not.toHaveBeenCalled();
@@ -86,6 +89,7 @@ describe(setCommentForReports, () => {
 			actor,
 			entity,
 			markdownReportPassMessage,
+			commentFooter,
 		);
 
 		expect(mockUpdateExistingCommentForReports).toHaveBeenCalledWith(
@@ -93,6 +97,7 @@ describe(setCommentForReports, () => {
 			entity,
 			existingComment,
 			markdownReportPassMessage,
+			commentFooter,
 		);
 		expect(actual).toEqual({
 			status: "existing",
@@ -106,13 +111,19 @@ describe(setCommentForReports, () => {
 	it("updates the comment when the report is a fail and there is an existing comment", async () => {
 		mockGetExistingComment.mockResolvedValueOnce(existingComment);
 
-		const actual = await setCommentForReports(actor, entity, reportFail);
+		const actual = await setCommentForReports(
+			actor,
+			entity,
+			reportFail,
+			commentFooter,
+		);
 
 		expect(mockUpdateExistingCommentForReports).toHaveBeenCalledWith(
 			actor,
 			entity,
 			existingComment,
 			reportFail,
+			commentFooter,
 		);
 		expect(actual).toEqual({
 			status: "existing",
@@ -128,12 +139,18 @@ describe(setCommentForReports, () => {
 		mockGetExistingComment.mockResolvedValueOnce(undefined);
 		mockCreateNewCommentForReports.mockResolvedValueOnce(newCommentUrl);
 
-		const actual = await setCommentForReports(actor, entity, reportFail);
+		const actual = await setCommentForReports(
+			actor,
+			entity,
+			reportFail,
+			commentFooter,
+		);
 
 		expect(mockCreateNewCommentForReports).toHaveBeenCalledWith(
 			actor,
 			entity,
 			reportFail,
+			commentFooter,
 		);
 		expect(actual).toEqual({
 			status: "created",

--- a/src/action/comments/setCommentForReports.test.ts
+++ b/src/action/comments/setCommentForReports.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { EntityActor } from "../../actors/types.js";
+import type { CommentConfig } from "../../types/commentConfig.js";
 import type { IssueEntity } from "../../types/entities.js";
 
 import { markdownReportPassMessage } from "../../reporters/markdownReporter.js";
@@ -64,9 +65,12 @@ const existingComment = {
 
 const reportFail = "Oh no!";
 
-describe(setCommentForReports, () => {
-	const commentFooter = "Test footer";
+const commentConfig = {
+	footer: "Test footer",
+	header: "Test header",
+} as CommentConfig;
 
+describe(setCommentForReports, () => {
 	it("returns without setting anything when the report is a pass and there is no existing comment", async () => {
 		mockGetExistingComment.mockResolvedValueOnce(undefined);
 
@@ -74,7 +78,7 @@ describe(setCommentForReports, () => {
 			actor,
 			entity,
 			markdownReportPassMessage,
-			commentFooter,
+			commentConfig,
 		);
 
 		expect(mockUpdateExistingCommentForReports).not.toHaveBeenCalled();
@@ -89,7 +93,7 @@ describe(setCommentForReports, () => {
 			actor,
 			entity,
 			markdownReportPassMessage,
-			commentFooter,
+			commentConfig,
 		);
 
 		expect(mockUpdateExistingCommentForReports).toHaveBeenCalledWith(
@@ -97,7 +101,7 @@ describe(setCommentForReports, () => {
 			entity,
 			existingComment,
 			markdownReportPassMessage,
-			commentFooter,
+			commentConfig,
 		);
 		expect(actual).toEqual({
 			status: "existing",
@@ -115,7 +119,7 @@ describe(setCommentForReports, () => {
 			actor,
 			entity,
 			reportFail,
-			commentFooter,
+			commentConfig,
 		);
 
 		expect(mockUpdateExistingCommentForReports).toHaveBeenCalledWith(
@@ -123,7 +127,7 @@ describe(setCommentForReports, () => {
 			entity,
 			existingComment,
 			reportFail,
-			commentFooter,
+			commentConfig,
 		);
 		expect(actual).toEqual({
 			status: "existing",
@@ -143,14 +147,14 @@ describe(setCommentForReports, () => {
 			actor,
 			entity,
 			reportFail,
-			commentFooter,
+			commentConfig,
 		);
 
 		expect(mockCreateNewCommentForReports).toHaveBeenCalledWith(
 			actor,
 			entity,
 			reportFail,
-			commentFooter,
+			commentConfig,
 		);
 		expect(actual).toEqual({
 			status: "created",

--- a/src/action/comments/setCommentForReports.test.ts
+++ b/src/action/comments/setCommentForReports.test.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it, vi } from "vitest";
 
 import type { EntityActor } from "../../actors/types.js";
-import type { CommentConfig } from "../../types/commentConfig.js";
 import type { IssueEntity } from "../../types/entities.js";
+import type { Settings } from "../../types/settings.js";
 
 import { markdownReportPassMessage } from "../../reporters/markdownReporter.js";
 import { setCommentForReports } from "./setCommentForReports.js";
@@ -65,10 +65,12 @@ const existingComment = {
 
 const reportFail = "Oh no!";
 
-const commentConfig = {
-	footer: "Test footer",
-	header: "Test header",
-} as CommentConfig;
+const settings = {
+	comments: {
+		footer: "Test footer",
+		header: "Test header",
+	},
+} satisfies Settings;
 
 describe(setCommentForReports, () => {
 	it("returns without setting anything when the report is a pass and there is no existing comment", async () => {
@@ -78,7 +80,7 @@ describe(setCommentForReports, () => {
 			actor,
 			entity,
 			markdownReportPassMessage,
-			commentConfig,
+			settings,
 		);
 
 		expect(mockUpdateExistingCommentForReports).not.toHaveBeenCalled();
@@ -93,7 +95,7 @@ describe(setCommentForReports, () => {
 			actor,
 			entity,
 			markdownReportPassMessage,
-			commentConfig,
+			settings,
 		);
 
 		expect(mockUpdateExistingCommentForReports).toHaveBeenCalledWith(
@@ -101,7 +103,7 @@ describe(setCommentForReports, () => {
 			entity,
 			existingComment,
 			markdownReportPassMessage,
-			commentConfig,
+			settings,
 		);
 		expect(actual).toEqual({
 			status: "existing",
@@ -119,7 +121,7 @@ describe(setCommentForReports, () => {
 			actor,
 			entity,
 			reportFail,
-			commentConfig,
+			settings,
 		);
 
 		expect(mockUpdateExistingCommentForReports).toHaveBeenCalledWith(
@@ -127,7 +129,7 @@ describe(setCommentForReports, () => {
 			entity,
 			existingComment,
 			reportFail,
-			commentConfig,
+			settings,
 		);
 		expect(actual).toEqual({
 			status: "existing",
@@ -147,14 +149,14 @@ describe(setCommentForReports, () => {
 			actor,
 			entity,
 			reportFail,
-			commentConfig,
+			settings,
 		);
 
 		expect(mockCreateNewCommentForReports).toHaveBeenCalledWith(
 			actor,
 			entity,
 			reportFail,
-			commentConfig,
+			settings,
 		);
 		expect(actual).toEqual({
 			status: "created",

--- a/src/action/comments/setCommentForReports.ts
+++ b/src/action/comments/setCommentForReports.ts
@@ -17,6 +17,7 @@ export async function setCommentForReports(
 	actor: EntityActor,
 	entity: Entity,
 	reported: string,
+	commentFooter: string,
 ): Promise<ReportComment | undefined> {
 	const existingComment = await getExistingComment(actor, entity.data.html_url);
 
@@ -34,6 +35,7 @@ export async function setCommentForReports(
 				entity,
 				existingComment,
 				reported,
+				commentFooter,
 			);
 		}
 		return (
@@ -48,6 +50,7 @@ export async function setCommentForReports(
 			entity,
 			existingComment,
 			reported,
+			commentFooter,
 		);
 		return { status: "existing", url: existingComment.html_url };
 	}
@@ -57,6 +60,7 @@ export async function setCommentForReports(
 		actor,
 		entity,
 		reported,
+		commentFooter,
 	);
 	core.info(`Created new comment: ${newCommentUrl}`);
 

--- a/src/action/comments/setCommentForReports.ts
+++ b/src/action/comments/setCommentForReports.ts
@@ -1,7 +1,7 @@
 import * as core from "@actions/core";
 
-import type { CommentConfig } from "../../types/commentConfig.js";
 import type { Entity } from "../../types/entities.js";
+import type { Settings } from "../../types/settings.js";
 
 import { EntityActor } from "../../actors/types.js";
 import { markdownReportPassMessage } from "../../reporters/markdownReporter.js";
@@ -18,7 +18,7 @@ export async function setCommentForReports(
 	actor: EntityActor,
 	entity: Entity,
 	reported: string,
-	commentConfig: CommentConfig,
+	settings: Settings,
 ): Promise<ReportComment | undefined> {
 	const existingComment = await getExistingComment(actor, entity.data.html_url);
 
@@ -36,7 +36,7 @@ export async function setCommentForReports(
 				entity,
 				existingComment,
 				reported,
-				commentConfig,
+				settings,
 			);
 		}
 		return (
@@ -51,7 +51,7 @@ export async function setCommentForReports(
 			entity,
 			existingComment,
 			reported,
-			commentConfig,
+			settings,
 		);
 		return { status: "existing", url: existingComment.html_url };
 	}
@@ -61,7 +61,7 @@ export async function setCommentForReports(
 		actor,
 		entity,
 		reported,
-		commentConfig,
+		settings,
 	);
 	core.info(`Created new comment: ${newCommentUrl}`);
 

--- a/src/action/comments/setCommentForReports.ts
+++ b/src/action/comments/setCommentForReports.ts
@@ -1,5 +1,6 @@
 import * as core from "@actions/core";
 
+import type { CommentConfig } from "../../types/commentConfig.js";
 import type { Entity } from "../../types/entities.js";
 
 import { EntityActor } from "../../actors/types.js";
@@ -17,7 +18,7 @@ export async function setCommentForReports(
 	actor: EntityActor,
 	entity: Entity,
 	reported: string,
-	commentFooter: string,
+	commentConfig: CommentConfig,
 ): Promise<ReportComment | undefined> {
 	const existingComment = await getExistingComment(actor, entity.data.html_url);
 
@@ -35,7 +36,7 @@ export async function setCommentForReports(
 				entity,
 				existingComment,
 				reported,
-				commentFooter,
+				commentConfig,
 			);
 		}
 		return (
@@ -50,7 +51,7 @@ export async function setCommentForReports(
 			entity,
 			existingComment,
 			reported,
-			commentFooter,
+			commentConfig,
 		);
 		return { status: "existing", url: existingComment.html_url };
 	}
@@ -60,7 +61,7 @@ export async function setCommentForReports(
 		actor,
 		entity,
 		reported,
-		commentFooter,
+		commentConfig,
 	);
 	core.info(`Created new comment: ${newCommentUrl}`);
 

--- a/src/action/comments/updateExistingCommentForReports.ts
+++ b/src/action/comments/updateExistingCommentForReports.ts
@@ -1,6 +1,6 @@
 import type { EntityActor } from "../../actors/types.js";
-import type { CommentConfig } from "../../types/commentConfig.js";
 import type { CommentData, Entity } from "../../types/entities.js";
+import type { Settings } from "../../types/settings.js";
 
 import { createCommentBody } from "./createCommentBody.js";
 
@@ -9,10 +9,10 @@ export async function updateExistingCommentForReports(
 	entity: Entity,
 	existingComment: CommentData,
 	reported: string,
-	commentConfig: CommentConfig,
+	settings: Settings,
 ) {
 	await actor.updateComment(
 		existingComment.id,
-		createCommentBody(entity, reported, commentConfig),
+		createCommentBody(entity, reported, settings),
 	);
 }

--- a/src/action/comments/updateExistingCommentForReports.ts
+++ b/src/action/comments/updateExistingCommentForReports.ts
@@ -1,4 +1,5 @@
 import type { EntityActor } from "../../actors/types.js";
+import type { CommentConfig } from "../../types/commentConfig.js";
 import type { CommentData, Entity } from "../../types/entities.js";
 
 import { createCommentBody } from "./createCommentBody.js";
@@ -8,10 +9,10 @@ export async function updateExistingCommentForReports(
 	entity: Entity,
 	existingComment: CommentData,
 	reported: string,
-	commentFooter: string,
+	commentConfig: CommentConfig,
 ) {
 	await actor.updateComment(
 		existingComment.id,
-		createCommentBody(entity, reported, commentFooter),
+		createCommentBody(entity, reported, commentConfig),
 	);
 }

--- a/src/action/comments/updateExistingCommentForReports.ts
+++ b/src/action/comments/updateExistingCommentForReports.ts
@@ -8,9 +8,10 @@ export async function updateExistingCommentForReports(
 	entity: Entity,
 	existingComment: CommentData,
 	reported: string,
+	commentFooter: string,
 ) {
 	await actor.updateComment(
 		existingComment.id,
-		createCommentBody(entity, reported),
+		createCommentBody(entity, reported, commentFooter),
 	);
 }

--- a/src/action/runOctoGuideAction.test.ts
+++ b/src/action/runOctoGuideAction.test.ts
@@ -1,0 +1,367 @@
+import type * as github from "@actions/github";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { EntityActor } from "../actors/types.js";
+import type { Entity } from "../types/entities.js";
+import type { RuleReport } from "../types/reports.js";
+
+import { runOctoGuideAction } from "./runOctoGuideAction";
+
+// Test constants
+const TEST_GITHUB_URL = "https://github.com/test";
+const TEST_GITHUB_TOKEN = "mock-token";
+const DEFAULT_REPORT_COUNT = 2;
+
+// Mock modules
+vi.mock("@actions/core");
+vi.mock("../index.js");
+vi.mock("../reporters/cliReporter.js");
+vi.mock("./runCommentCleanup.js");
+vi.mock("./comments/outputActionReports.js");
+
+// Import mocked modules
+import * as core from "@actions/core";
+
+import { runOctoGuideRules } from "../index.js";
+import { cliReporter } from "../reporters/cliReporter.js";
+import { outputActionReports } from "./comments/outputActionReports.js";
+import { runCommentCleanup } from "./runCommentCleanup.js";
+
+// Get typed mock references
+const mockCore = vi.mocked(core);
+const mockRunOctoGuideRules = vi.mocked(runOctoGuideRules);
+const mockCliReporter = vi.mocked(cliReporter);
+const mockRunCommentCleanup = vi.mocked(runCommentCleanup);
+const mockOutputActionReports = vi.mocked(outputActionReports);
+
+/**
+ * Factory for creating minimal mock issue data with only the properties used by the implementation.
+ * @param overrides Partial overrides to customize the mock issue data
+ * @returns Mock issue object with html_url and any provided overrides
+ * @example
+ * ```typescript
+ * const issue = createMockIssue({ html_url: "https://github.com/owner/repo/issues/123" });
+ * ```
+ */
+const createMockIssue = (overrides: Partial<{ html_url: string }> = {}) => ({
+	html_url: TEST_GITHUB_URL,
+	...overrides,
+});
+
+/**
+ * Creates a mock Entity object for testing purposes.
+ * @param dataOverrides Partial overrides for the entity's data property
+ * @returns Complete Entity mock with realistic defaults
+ * @example
+ * ```typescript
+ * const entity = createMockEntity({ html_url: "https://github.com/owner/repo/issues/456" });
+ * ```
+ */
+const createMockEntity = (
+	dataOverrides: Partial<{ html_url: string }> = {},
+): Entity =>
+	({
+		data: createMockIssue(dataOverrides),
+		number: 1,
+		type: "issue",
+	}) as Entity;
+
+/**
+ * Creates a mock EntityActor with all required methods stubbed as vi.fn().
+ * @returns EntityActor mock with realistic method signatures
+ * @example
+ * ```typescript
+ * const actor = createMockActor();
+ * actor.createComment.mockResolvedValue({ id: 123 });
+ * ```
+ */
+const createMockActor = (): EntityActor =>
+	({
+		createComment: vi.fn(),
+		getData: vi.fn(),
+		listComments: vi.fn(),
+		metadata: { number: 1, type: "issue" } as const,
+		updateComment: vi.fn(),
+	}) as EntityActor;
+
+/**
+ * Creates a mock GitHub webhook payload with sensible defaults.
+ * Simulates the structure of GitHub webhook payloads for various events.
+ * @param overrides Partial overrides to customize specific payload properties
+ * @returns GitHub context payload mock
+ * @example
+ * ```typescript
+ * const payload = createMockPayload({ action: "closed", issue: { number: 42 } });
+ * ```
+ */
+const createMockPayload = (
+	overrides: Partial<typeof github.context.payload> = {},
+): typeof github.context.payload => ({
+	action: "opened",
+	issue: { html_url: TEST_GITHUB_URL, number: 1 },
+	...overrides,
+});
+
+/**
+ * Creates a minimal GitHub context mock for testing GitHub Actions.
+ * Only includes essential properties required by the implementation.
+ * @param payload The webhook payload to include in the context
+ * @returns GitHub context mock with minimal required properties
+ * @example
+ * ```typescript
+ * const context = createMockContext(createMockPayload({ action: "edited" }));
+ * ```
+ */
+const createMockContext = (payload: typeof github.context.payload) => {
+	return {
+		eventName: "issue" as const,
+		payload,
+		repo: { owner: "owner", repo: "repo" },
+	} satisfies Partial<typeof github.context> as typeof github.context;
+};
+
+/**
+ * Sets up mock implementations for GitHub Action inputs.
+ * Simulates the behavior of @actions/core.getInput() for workflow inputs.
+ * @param overrides Key-value pairs of input names and their mock values
+ * @example
+ * ```typescript
+ * createMockActionInputs({
+ *   config: "strict",
+ *   "github-token": "ghp_test123"
+ * });
+ * ```
+ */
+const createMockActionInputs = (overrides: Record<string, string> = {}) => {
+	const inputs: Record<string, string> = {
+		config: "recommended",
+		"github-token": TEST_GITHUB_TOKEN,
+		...overrides,
+	};
+
+	mockCore.getInput.mockImplementation((name: string) => inputs[name] ?? "");
+};
+
+/**
+ * Sets up a successful rule execution mock with no reports found.
+ * Useful for testing happy path scenarios where no violations are detected.
+ * @returns The mock result object that will be returned by runOctoGuideRules
+ * @example
+ * ```typescript
+ * const result = createMinimalRuleExecution();
+ * // result.reports will be an empty array
+ * ```
+ */
+const createMinimalRuleExecution = () => {
+	const actor = createMockActor();
+	(actor.listComments as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+	const mockResult = {
+		actor,
+		entity: createMockEntity(),
+		reports: [],
+	};
+	mockRunOctoGuideRules.mockResolvedValueOnce(mockResult);
+	return mockResult;
+};
+
+/**
+ * Sets up a rule execution mock that returns a specified number of violation reports.
+ * Useful for testing scenarios where rule violations are detected and need to be handled.
+ * @param reportCount Number of mock reports to generate (default: 2)
+ * @returns The mock result object containing the generated reports
+ * @example
+ * ```typescript
+ * const result = mockRuleExecutionWithReports(3);
+ * // result.reports will contain 3 mock RuleReport objects
+ * ```
+ */
+const mockRuleExecutionWithReports = (reportCount = DEFAULT_REPORT_COUNT) => {
+	const reports = Array.from({ length: reportCount }, () =>
+		createMockTestReport(),
+	);
+	const actor = createMockActor();
+	(actor.listComments as ReturnType<typeof vi.fn>).mockResolvedValue([]);
+
+	const mockResult = {
+		actor,
+		entity: createMockEntity(),
+		reports,
+	};
+	mockRunOctoGuideRules.mockResolvedValueOnce(mockResult);
+	return mockResult;
+};
+
+/**
+ * Factory for creating realistic RuleReport test objects.
+ * Generates reports with all required properties and sensible defaults.
+ * @param overrides Partial overrides to customize specific report properties
+ * @returns Complete RuleReport mock with realistic structure
+ * @example
+ * ```typescript
+ * const report = createMockTestReport({
+ *   about: { name: "custom-rule" },
+ *   data: { primary: "Custom violation message" }
+ * });
+ * ```
+ */
+const createMockTestReport = (
+	overrides: Partial<RuleReport> = {},
+): RuleReport => ({
+	about: {
+		description: "Test rule description",
+		explanation: ["Test explanation"],
+		name: "test-rule",
+		url: "https://example.com",
+	},
+	data: {
+		primary: "Test primary data",
+		secondary: [],
+		suggestion: ["fix this issue"],
+	},
+	...overrides,
+});
+
+// Store original environment state for cleanup
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	// Reset to original state
+	process.env = { ...originalEnv };
+});
+
+describe("runOctoGuideAction", () => {
+	it("should log success message when no violations are detected", async () => {
+		createMockActionInputs();
+		createMinimalRuleExecution();
+
+		await runOctoGuideAction(createMockContext(createMockPayload()));
+
+		expect(mockCore.info).toHaveBeenCalledWith("Found 0 reports. Great! ✅");
+	});
+
+	it("should log report count and CLI output when violations are found", async () => {
+		const consoleSpy = vi
+			.spyOn(console, "log")
+			.mockImplementation(() => undefined);
+		createMockActionInputs();
+		mockRuleExecutionWithReports(2);
+		mockCliReporter.mockReturnValue("Mocked CLI report");
+
+		await runOctoGuideAction(createMockContext(createMockPayload()));
+
+		expect(mockCore.info).toHaveBeenCalledWith("Found 2 report(s).");
+		expect(consoleSpy).toHaveBeenCalledWith("Mocked CLI report");
+	});
+
+	it("should call outputActionReports with correct parameters when reports are found", async () => {
+		vi.spyOn(console, "log").mockImplementation(() => undefined);
+		createMockActionInputs();
+		const { reports } = mockRuleExecutionWithReports(2);
+		mockCliReporter.mockReturnValue("Mocked CLI report");
+
+		await runOctoGuideAction(createMockContext(createMockPayload()));
+
+		expect(mockOutputActionReports).toHaveBeenCalledWith(
+			expect.objectContaining({ metadata: { number: 1, type: "issue" } }),
+			expect.objectContaining({
+				data: { html_url: "https://github.com/test" },
+			}),
+			reports,
+		);
+	});
+
+	it("should call outputActionReports even when no reports are found", async () => {
+		createMockActionInputs();
+		createMinimalRuleExecution();
+
+		await runOctoGuideAction(createMockContext(createMockPayload()));
+
+		expect(mockOutputActionReports).toHaveBeenCalledWith(
+			expect.objectContaining({ metadata: { number: 1, type: "issue" } }),
+			expect.objectContaining({
+				data: { html_url: "https://github.com/test" },
+			}),
+			[],
+		);
+	});
+
+	it("should exit gracefully when payload action is unknown", async () => {
+		createMockActionInputs();
+
+		await runOctoGuideAction(
+			createMockContext(createMockPayload({ action: undefined })),
+		);
+
+		expect(mockCore.info).toHaveBeenCalledWith(
+			"Unknown payload action. Exiting.",
+		);
+	});
+
+	it("should throw error when entity cannot be determined from payload", async () => {
+		createMockActionInputs();
+
+		await expect(
+			runOctoGuideAction(createMockContext({ action: "opened" })),
+		).rejects.toThrow("Could not determine an entity to run OctoGuide on.");
+	});
+
+	it("should throw authentication error when GitHub token is missing", async () => {
+		createMockActionInputs({ "github-token": "" });
+		// Mock process.env.GITHUB_TOKEN to be undefined
+		delete process.env.GITHUB_TOKEN;
+
+		await expect(
+			runOctoGuideAction(createMockContext(createMockPayload())),
+		).rejects.toThrow("Please provide a with.github-token to octoguide.");
+	});
+
+	it("should run comment cleanup when entity is deleted", async () => {
+		createMockActionInputs();
+		const payload = createMockPayload({ action: "deleted" });
+
+		await runOctoGuideAction(createMockContext(payload));
+
+		expect(mockRunCommentCleanup).toHaveBeenCalledWith({
+			auth: "mock-token",
+			payload,
+			url: "https://github.com/test",
+		});
+	});
+
+	it("should throw error when unknown config is provided", async () => {
+		createMockActionInputs({ config: "unknown-config" });
+
+		await expect(
+			runOctoGuideAction(createMockContext(createMockPayload())),
+		).rejects.toThrow("Unknown config provided: unknown-config");
+	});
+
+	it("should use explicit config when specified in action inputs", async () => {
+		createMockActionInputs({ config: "strict" });
+		createMinimalRuleExecution();
+
+		await runOctoGuideAction(createMockContext(createMockPayload()));
+
+		expect(mockRunOctoGuideRules).toHaveBeenCalledWith({
+			auth: "mock-token",
+			config: "strict",
+			entity: "https://github.com/test",
+		});
+	});
+
+	it("should fall back to recommended config when input is empty", async () => {
+		createMockActionInputs({ config: "" }); // Empty string should fall back to "recommended"
+		createMinimalRuleExecution();
+
+		await runOctoGuideAction(createMockContext(createMockPayload()));
+
+		expect(mockRunOctoGuideRules).toHaveBeenCalledWith({
+			auth: "mock-token",
+			config: "recommended",
+			entity: "https://github.com/test",
+		});
+	});
+});

--- a/src/action/runOctoGuideAction.test.ts
+++ b/src/action/runOctoGuideAction.test.ts
@@ -270,6 +270,7 @@ describe("runOctoGuideAction", () => {
 				data: { html_url: "https://github.com/test" },
 			}),
 			reports,
+			"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
 		);
 	});
 
@@ -285,6 +286,7 @@ describe("runOctoGuideAction", () => {
 				data: { html_url: "https://github.com/test" },
 			}),
 			[],
+			"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
 		);
 	});
 
@@ -363,5 +365,36 @@ describe("runOctoGuideAction", () => {
 			config: "recommended",
 			entity: "https://github.com/test",
 		});
+	});
+
+	it("should use the default footer comment when no footer is specified in config", async () => {
+		createMockActionInputs({});
+		createMinimalRuleExecution();
+		await runOctoGuideAction(createMockContext(createMockPayload()));
+
+		expect(mockOutputActionReports).toHaveBeenCalledWith(
+			expect.objectContaining({ metadata: { number: 1, type: "issue" } }),
+			expect.objectContaining({
+				data: { html_url: "https://github.com/test" },
+			}),
+			expect.anything(),
+			"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
+		);
+	});
+
+	it("should use the custom footer comment when specified in config", async () => {
+		createMockActionInputs({
+			"comment-footer": "Custom footer message!",
+		});
+		createMinimalRuleExecution();
+		await runOctoGuideAction(createMockContext(createMockPayload()));
+		expect(mockOutputActionReports).toHaveBeenCalledWith(
+			expect.objectContaining({ metadata: { number: 1, type: "issue" } }),
+			expect.objectContaining({
+				data: { html_url: "https://github.com/test" },
+			}),
+			expect.anything(),
+			"Custom footer message!",
+		);
 	});
 });

--- a/src/action/runOctoGuideAction.test.ts
+++ b/src/action/runOctoGuideAction.test.ts
@@ -271,9 +271,11 @@ describe("runOctoGuideAction", () => {
 			}),
 			reports,
 			expect.objectContaining({
-				footer:
-					"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
-				header: "Hey! You! Listen! This is a bot message from Octoguide! 🐙",
+				comments: {
+					footer:
+						"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
+					header: "",
+				},
 			}),
 		);
 	});
@@ -291,9 +293,11 @@ describe("runOctoGuideAction", () => {
 			}),
 			[],
 			expect.objectContaining({
-				footer:
-					"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
-				header: "Hey! You! Listen! This is a bot message from Octoguide! 🐙",
+				comments: {
+					footer:
+						"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
+					header: "",
+				},
 			}),
 		);
 	});
@@ -387,8 +391,11 @@ describe("runOctoGuideAction", () => {
 			}),
 			expect.anything(),
 			expect.objectContaining({
-				footer:
-					"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
+				comments: {
+					footer:
+						"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
+					header: "",
+				},
 			}),
 		);
 	});
@@ -406,7 +413,10 @@ describe("runOctoGuideAction", () => {
 			}),
 			expect.anything(),
 			expect.objectContaining({
-				footer: "Custom footer message!",
+				comments: {
+					footer: "Custom footer message!",
+					header: "",
+				},
 			}),
 		);
 	});

--- a/src/action/runOctoGuideAction.test.ts
+++ b/src/action/runOctoGuideAction.test.ts
@@ -270,7 +270,11 @@ describe("runOctoGuideAction", () => {
 				data: { html_url: "https://github.com/test" },
 			}),
 			reports,
-			"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
+			expect.objectContaining({
+				footer:
+					"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
+				header: "Hey! You! Listen! This is a bot message from Octoguide! 🐙",
+			}),
 		);
 	});
 
@@ -286,7 +290,11 @@ describe("runOctoGuideAction", () => {
 				data: { html_url: "https://github.com/test" },
 			}),
 			[],
-			"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
+			expect.objectContaining({
+				footer:
+					"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
+				header: "Hey! You! Listen! This is a bot message from Octoguide! 🐙",
+			}),
 		);
 	});
 
@@ -378,7 +386,10 @@ describe("runOctoGuideAction", () => {
 				data: { html_url: "https://github.com/test" },
 			}),
 			expect.anything(),
-			"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
+			expect.objectContaining({
+				footer:
+					"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
+			}),
 		);
 	});
 
@@ -394,7 +405,9 @@ describe("runOctoGuideAction", () => {
 				data: { html_url: "https://github.com/test" },
 			}),
 			expect.anything(),
-			"Custom footer message!",
+			expect.objectContaining({
+				footer: "Custom footer message!",
+			}),
 		);
 	});
 });

--- a/src/action/runOctoGuideAction.ts
+++ b/src/action/runOctoGuideAction.ts
@@ -48,13 +48,12 @@ export async function runOctoGuideAction(context: typeof github.context) {
 		throw new Error(`Unknown config provided: ${config}`);
 	}
 
-	const commentConfig = {
-		footer:
+	const settings = {
+		comments: {
+		  footer:
 			core.getInput("comment-footer") ||
 			"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
-		header:
-			core.getInput("comment-header") ||
-			"Hey! You! Listen! This is a bot message from Octoguide! 🐙",
+		header: core.getInput("comment-header"),
 	};
 
 	const { actor, entity, reports } = await runOctoGuideRules({

--- a/src/action/runOctoGuideAction.ts
+++ b/src/action/runOctoGuideAction.ts
@@ -50,10 +50,11 @@ export async function runOctoGuideAction(context: typeof github.context) {
 
 	const settings = {
 		comments: {
-		  footer:
-			core.getInput("comment-footer") ||
-			"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
-		header: core.getInput("comment-header"),
+			footer:
+				core.getInput("comment-footer") ||
+				"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
+			header: core.getInput("comment-header"),
+		},
 	};
 
 	const { actor, entity, reports } = await runOctoGuideRules({
@@ -69,5 +70,5 @@ export async function runOctoGuideAction(context: typeof github.context) {
 		core.info("Found 0 reports. Great! ✅");
 	}
 
-	await outputActionReports(actor, entity, reports, commentConfig);
+	await outputActionReports(actor, entity, reports, settings);
 }

--- a/src/action/runOctoGuideAction.ts
+++ b/src/action/runOctoGuideAction.ts
@@ -48,6 +48,10 @@ export async function runOctoGuideAction(context: typeof github.context) {
 		throw new Error(`Unknown config provided: ${config}`);
 	}
 
+	const commentFooter =
+		core.getInput("comment-footer") ||
+		"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.";
+
 	const { actor, entity, reports } = await runOctoGuideRules({
 		auth,
 		config,
@@ -61,5 +65,5 @@ export async function runOctoGuideAction(context: typeof github.context) {
 		core.info("Found 0 reports. Great! ✅");
 	}
 
-	await outputActionReports(actor, entity, reports);
+	await outputActionReports(actor, entity, reports, commentFooter);
 }

--- a/src/action/runOctoGuideAction.ts
+++ b/src/action/runOctoGuideAction.ts
@@ -48,9 +48,14 @@ export async function runOctoGuideAction(context: typeof github.context) {
 		throw new Error(`Unknown config provided: ${config}`);
 	}
 
-	const commentFooter =
-		core.getInput("comment-footer") ||
-		"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.";
+	const commentConfig = {
+		footer:
+			core.getInput("comment-footer") ||
+			"🗺️ This message was posted automatically by [OctoGuide](https://octo.guide): a bot for GitHub repository best practices.",
+		header:
+			core.getInput("comment-header") ||
+			"Hey! You! Listen! This is a bot message from Octoguide! 🐙",
+	};
 
 	const { actor, entity, reports } = await runOctoGuideRules({
 		auth,
@@ -65,5 +70,5 @@ export async function runOctoGuideAction(context: typeof github.context) {
 		core.info("Found 0 reports. Great! ✅");
 	}
 
-	await outputActionReports(actor, entity, reports, commentFooter);
+	await outputActionReports(actor, entity, reports, commentConfig);
 }

--- a/src/types/commentConfig.ts
+++ b/src/types/commentConfig.ts
@@ -1,4 +1,0 @@
-export interface CommentConfig {
-	footer: string;
-	header: string;
-}

--- a/src/types/commentConfig.ts
+++ b/src/types/commentConfig.ts
@@ -1,0 +1,4 @@
+export interface CommentConfig {
+	footer: string;
+	header: string;
+}

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,0 +1,8 @@
+export interface Settings {
+	comments: Comments;
+}
+
+interface Comments {
+	footer: string;
+	header: string;
+}


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to OctoGuide! 🗺️
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: closes #193 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/OctoGuide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/OctoGuide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Adds a comment header for octoguide and allows comment header and comment footer to be configured in the action. 

🎸