### PR TITLE
chore(knip): remove redundant src/index.ts from entry config

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -5,7 +5,6 @@
 		"site/src/**/*.astro",
 		"src/action/index.ts",
 		"src/cli.ts",
-		"src/index.ts",
 		"src/**/*.test.*"
 	],
 	"ignore": ["dist/index.js"],


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to OctoGuide! 🗺️
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #213 
- [ ] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/OctoGuide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/OctoGuide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Removes redundant entry config from knip.json. Running `pnpm lint:knip` should now return no configuration hints.

 🎸
