### PR TITLE
docs: generate included in metadata automatically

### DIFF
--- a/site/src/components/IncludedIn.astro
+++ b/site/src/components/IncludedIn.astro
@@ -26,7 +26,8 @@ const configs = getRuleConfigs(rule.about.config);
 ---
 
 <blockquote>
-	Included in configs: {
+	Included in {configs.length === 1 ? "config:" : "configs:"}
+	{
 		configs.map((config, i) => (
 			<>
 				{configEmojis[config]}&nbsp;{config}

--- a/site/src/components/IncludedIn.astro
+++ b/site/src/components/IncludedIn.astro
@@ -1,7 +1,7 @@
 ---
 import type { ConfigName } from "../../../src/types/core";
 import { allRules } from "../../../src/rules/all.js";
-import { configEmojis } from "src/data/configEmojis";
+import { configEmojis } from "../data/configEmojis";
 
 interface Props {
 	rule: string;

--- a/site/src/components/IncludedIn.astro
+++ b/site/src/components/IncludedIn.astro
@@ -1,0 +1,37 @@
+---
+import type { ConfigName } from "../../../src/types/core";
+import { allRules } from "../../../src/rules/all.js";
+import { configEmojis } from "src/data/configEmojis";
+
+interface Props {
+	rule: string;
+}
+
+const { rule: ruleName } = Astro.props;
+const rule = allRules.find((r) => r.about.name === ruleName);
+
+if (!rule) {
+	throw new Error(`Rule ${ruleName} not found`);
+}
+
+function getRuleConfigs(config: ConfigName) {
+	const configs: ConfigName[] = [config];
+	if (config === "recommended") {
+		configs.push("strict");
+	}
+	return configs;
+}
+
+const configs = getRuleConfigs(rule.about.config);
+---
+
+<blockquote>
+	Included in configs: {
+		configs.map((config, i) => (
+			<>
+				{configEmojis[config]}&nbsp;{config}
+				{i < configs.length - 1 ? ", " : ""}
+			</>
+		))
+	}
+</blockquote>

--- a/site/src/components/RulesTable.astro
+++ b/site/src/components/RulesTable.astro
@@ -3,11 +3,7 @@ import { marked } from "marked";
 
 import { allRules } from "../../../src/rules/all.js";
 import type { Rule } from "../../../src/types/rules.js";
-
-const configEmojis = {
-	recommended: "✅",
-	strict: "🔒",
-};
+import { configEmojis } from "src/data/configEmojis";
 
 function getRuleArea(rule: Rule) {
 	switch (rule.about.name.split("-")[0]) {

--- a/site/src/components/RulesTable.astro
+++ b/site/src/components/RulesTable.astro
@@ -3,7 +3,7 @@ import { marked } from "marked";
 
 import { allRules } from "../../../src/rules/all.js";
 import type { Rule } from "../../../src/types/rules.js";
-import { configEmojis } from "src/data/configEmojis";
+import { configEmojis } from "../data/configEmojis";
 
 function getRuleArea(rule: Rule) {
 	switch (rule.about.name.split("-")[0]) {

--- a/site/src/content/docs/rules/comment-meaningless.mdx
+++ b/site/src/content/docs/rules/comment-meaningless.mdx
@@ -4,8 +4,9 @@ title: "comment-meaningless"
 ---
 
 import OctoGuideGitHubComment from "../../../components/OctoGuideGitHubComment.astro";
+import IncludedIn from "../../../components/IncludedIn.astro";
 
-> Included in configs: ✅ recommended, 🔒 strict
+<IncludedIn rule="comment-meaningless" />
 
 Posting replies containing just _"+1"_, _any update?"_, or other phrases without new information don't meaningfully contribute to a discussion.
 If done too much, they can even become disruptive to other contributors.

--- a/site/src/content/docs/rules/pr-body-not-empty.mdx
+++ b/site/src/content/docs/rules/pr-body-not-empty.mdx
@@ -4,8 +4,9 @@ title: "pr-body-not-empty"
 ---
 
 import OctoGuideGitHubComment from "../../../components/OctoGuideGitHubComment.astro";
+import IncludedIn from "../../../components/IncludedIn.astro";
 
-> Included in configs: ✅ recommended, 🔒 strict
+<IncludedIn rule="pr-body-not-empty" />
 
 This repository expects pull requests to include a description explaining the changes.
 The description should have at least one word not in the PR template, or any content if no template exists.

--- a/site/src/content/docs/rules/pr-branch-non-default.mdx
+++ b/site/src/content/docs/rules/pr-branch-non-default.mdx
@@ -4,8 +4,9 @@ title: "pr-branch-non-default"
 ---
 
 import OctoGuideGitHubComment from "../../../components/OctoGuideGitHubComment.astro";
+import IncludedIn from "../../../components/IncludedIn.astro";
 
-> Included in configs: ✅ recommended, 🔒 strict
+<IncludedIn rule="pr-branch-non-default" />
 
 Sending a PR from a repository's default branch, commonly `main`, means that repository will have a hard time pulling in updates from the upstream repository.
 It's generally recommended to instead create a new branch per pull request.

--- a/site/src/content/docs/rules/pr-linked-issue.mdx
+++ b/site/src/content/docs/rules/pr-linked-issue.mdx
@@ -4,8 +4,9 @@ title: "pr-linked-issue"
 ---
 
 import OctoGuideGitHubComment from "../../../components/OctoGuideGitHubComment.astro";
+import IncludedIn from "../../../components/IncludedIn.astro";
 
-> Included in config: 🔒 strict
+<IncludedIn rule="pr-linked-issue" />
 
 A repository using this rule keeps to GitHub issues for discussing potential changes.
 Most or all changes should be marked as approved in an issue before a pull request is sent to resolve them.

--- a/site/src/content/docs/rules/pr-task-completion.mdx
+++ b/site/src/content/docs/rules/pr-task-completion.mdx
@@ -4,8 +4,9 @@ title: "pr-task-completion"
 ---
 
 import OctoGuideGitHubComment from "../../../components/OctoGuideGitHubComment.astro";
+import IncludedIn from "../../../components/IncludedIn.astro";
 
-> Included in configs: ✅ recommended, 🔒 strict
+<IncludedIn rule="pr-task-completion" />
 
 Repositories often provide a set of tasks that pull request authors are expected to complete.
 Those tasks should be marked as completed with a `[x]` in the pull request description.

--- a/site/src/content/docs/rules/pr-title-conventional.mdx
+++ b/site/src/content/docs/rules/pr-title-conventional.mdx
@@ -4,8 +4,9 @@ title: "pr-title-conventional"
 ---
 
 import OctoGuideGitHubComment from "../../../components/OctoGuideGitHubComment.astro";
+import IncludedIn from "../../../components/IncludedIn.astro";
 
-> Included in config: 🔒 strict
+<IncludedIn rule="pr-title-conventional" />
 
 A repository using this rule enforces that pull request titles follow the [Conventional Commits](https://www.conventionalcommits.org) format.
 Doing so helps to ensure that the purpose of a pull request is clear and consistent for humans and machines.

--- a/site/src/content/docs/rules/text-image-alt-text.mdx
+++ b/site/src/content/docs/rules/text-image-alt-text.mdx
@@ -4,8 +4,9 @@ title: "text-image-alt-text"
 ---
 
 import OctoGuideGitHubComment from "../../../components/OctoGuideGitHubComment.astro";
+import IncludedIn from "../../../components/IncludedIn.astro";
 
-> Included in config: ✅ recommended, 🔒 strict
+<IncludedIn rule="text-image-alt-text" />
 
 Alternative text, or "alt text", is a description attached to an image.
 It allows non-sighted users and tools to understand the image despite not being able to visually see it.

--- a/site/src/data/configEmojis.ts
+++ b/site/src/data/configEmojis.ts
@@ -1,0 +1,4 @@
+export const configEmojis = {
+	recommended: "✅",
+	strict: "🔒",
+};


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to OctoGuide! 🗺️
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #66 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/OctoGuide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/OctoGuide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Creates  IncludedIn component to display what configs the rule is included in. The component takes in a rule name and returns the configs from the rule's metadata.

🥏