### PR TITLE
chore(knip): enable treatConfigHintsAsErrors

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -1,5 +1,6 @@
 {
-	"$schema": "https://unpkg.com/knip@5.46.0/schema.json",
+	"$schema": "https://unpkg.com/knip@5.62.0/schema.json",
+	"treatConfigHintsAsErrors": true,
 	"entry": [
 		"site/**/*.mdx",
 		"site/src/**/*.astro",


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to OctoGuide! 🗺️
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #217 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/OctoGuide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/OctoGuide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Enables treatConfigHintsAsErrors for knip. This can be tested by adding `"src/index.ts",` back to the knip.json entry config and seeing the config hint and exit 1.

✂️