### PR TITLE
docs: add config:none to get-started configuration

### DIFF
--- a/site/src/content/docs/get-started.mdx
+++ b/site/src/content/docs/get-started.mdx
@@ -7,6 +7,7 @@ import { Code } from "@astrojs/starlight/components";
 import {
 	getStartedBase,
 	getStartedStrict,
+	getStartedNone,
 	getStartedHeader,
 	getStartedFooter,
 	getStartedRuleDisable,
@@ -52,6 +53,17 @@ You can extend it to use a _strict_ superset by adding `config: strict` to the a
 />
 
 The _strict_ config includes all rules from _recommended_ plus more rules that enforce more opinionated practices.
+
+You can also use no config by setting `config: none` in the action's `with`:
+
+<Code
+	code={getStartedNone}
+	meta="lang=yml"
+	lang="diff"
+	title=".github/workflows/octoguide.yml"
+/>
+
+The _none_ config includes no rules. Only rules explicitly enabled in the config will be enforced.
 
 See [Preset Configs](./configs) for more information on preset configs and their rules.
 

--- a/site/src/data/yml.ts
+++ b/site/src/data/yml.ts
@@ -43,6 +43,18 @@ jobs:
 +          config: strict
           github-token: \${{ secrets.GITHUB_TOKEN }}`;
 
+export const getStartedNone = `
+jobs:
+  octoguide:
+    if: \${{ !endsWith(github.actor, '[bot]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JoshuaKGoldberg/octoguide${atVersion}
+        with:
++          config: none
+          github-token: \${{ secrets.GITHUB_TOKEN }}
+          pr-linked-issue: "true"`;
+
 export const getStartedHeader = `jobs:
   octoguide:
     if: \${{ !endsWith(github.actor, '[bot]') }}


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to OctoGuide! 🗺️
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #258
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/OctoGuide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/OctoGuide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Adds config:none section to the get-started configuration section.

📄