### PR TITLE
feat: add config for exclude-bots

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,14 +5,18 @@ branding:
 description: Runs OctoGuide as a GitHub Action. 🗺️
 inputs:
   comment-footer:
-    description: Custom footer text for bot comments.
+    description: Custom footer text for OctoGuide bot comments.
     required: false
   comment-header:
-    description: Custom header text for bot comments.
+    description: Custom header text for OctoGuide bot comments.
     required: false
   config:
     default: recommended
     description: Which config to use, as 'recommended' (default), 'strict', or 'none'.
+    required: false
+  exclude-bots:
+    default: "true"
+    description: Skip running OctoGuide rules for bot-created entities (issues, PRs, discussions) and comments.
     required: false
   github-token:
     description: GitHub token (PAT) with repo and workflow permissions.

--- a/site/src/content/docs/get-started.mdx
+++ b/site/src/content/docs/get-started.mdx
@@ -13,6 +13,7 @@ import {
 	getStartedRuleDisable,
 	getStartedRuleEnable,
 	getStartedRuleNone,
+	getStartedExcludeBotsFalse,
 } from "../../data/yml.js";
 
 OctoGuide checks that contributor activity on your GitHub repository aligns with common expectations of smoothly-running projects.
@@ -77,6 +78,28 @@ For public repositories that's the following permissions:
 
 - `repo` > `public_repo`
 - `read:discussion`
+
+### `exclude-bots`
+
+OctoGuide by default skips running rules for bot-created entities (issues, pull requests, and discussions)
+and comments. This is useful because automated tools like Dependabot, Renovate,
+and other GitHub Apps often create PRs and issues or make comments that don't
+necessarily need to follow the same contribution guidelines as human contributors.
+
+Bot detection works by checking if the entity creator's `user.type` field is `"Bot"`,
+which is the standard way GitHub identifies bot accounts and GitHub Apps.
+
+If you want OctoGuide to run rules on bot-created entities and comments, you can
+disable this by setting `exclude-bots` to `"false"`:
+
+**Example:**
+
+<Code
+	code={getStartedExcludeBotsFalse}
+	meta="lang=yml"
+	lang="diff"
+	title=".github/workflows/octoguide.yml"
+/>
 
 ### `comment-header`
 

--- a/site/src/data/yml.ts
+++ b/site/src/data/yml.ts
@@ -108,3 +108,13 @@ export const getStartedRuleNone = `jobs:
           github-token: \${{ secrets.GITHUB_TOKEN }}
 +          pr-linked-issue: "true"
 +          text-image-alt-text: "true"`;
+
+export const getStartedExcludeBotsFalse = `jobs:
+  octoguide:
+    if: \${{ !endsWith(github.actor, '[bot]') }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: JoshuaKGoldberg/octoguide${atVersion}
+        with:
++          exclude-bots: "false"
+          github-token: \${{ secrets.GITHUB_TOKEN }}`;

--- a/src/action/runOctoGuideAction.ts
+++ b/src/action/runOctoGuideAction.ts
@@ -99,6 +99,26 @@ export async function runOctoGuideAction(context: typeof github.context) {
 		type: entityType,
 	} as Entity;
 
+	/**
+	 * Determines if an entity was created by a bot based on the user.type field.
+	 * @param entity The entity to check
+	 * @returns true if the entity was created by a bot (user.type === "Bot"), false otherwise
+	 */
+	const isEntityFromBot = (entity: Entity): boolean => {
+		const user = entity.data.user as
+			| undefined
+			| { login: string; type?: string };
+
+		return user?.type === "Bot";
+	};
+
+	// Check if we should exclude bots
+	const excludeBots = core.getInput("exclude-bots") !== "false";
+	if (excludeBots && isEntityFromBot(entityInput)) {
+		core.info(`Skipping OctoGuide rules for bot-created ${entityType}: ${url}`);
+		return;
+	}
+
 	const { actor, entity, reports } = await runOctoGuideRules({
 		auth,
 		entity: entityInput,


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to OctoGuide! 🗺️
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #313 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/OctoGuide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/OctoGuide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Adds config to exempt bots from OctoGuide rules.

🤖