### PR TITLE
chore(renovate): override npm minimumReleaseAge

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -17,21 +17,9 @@
 			"minimumReleaseAge": "7 days"
 		},
 		{
-			"description": "Do not require Minimum Release Age for update types that are controlled by the package manager",
-			"matchDatasources": ["npm"],
-			"matchUpdateTypes": ["lockFileMaintenance"],
-			"prBodyNotes": [
-				"⚠️ Renovate's lock file maintenance functionality does not support validating Minimum Release Age, as the package manager performs the required changes to update package(s). Confirm whether your package manager perform its own validation for the Minimum Release Age of packages."
-			],
-			"minimumReleaseAge": null
-		},
-		{
-			"description": "Do not require Minimum Release Age for package replacements",
+			"description": "Default to PNPM Minimum Release Age for package replacements",
 			"matchDatasources": ["npm"],
 			"matchUpdateTypes": ["replacement"],
-			"prBodyNotes": [
-				"⚠️ Renovate's replacement functionality [does not currently](https://github.com/renovatebot/renovate/issues/39400) wire in the release age for a package, so the Minimum Release Age checks can apply. You will need to manually validate the Minimum Release Age for these package(s)."
-			],
 			"minimumReleaseAge": null
 		}
 	]


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to OctoGuide! 🗺️
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #383 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/OctoGuide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/OctoGuide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Default security updates [added to the config:best-practices in renovate 42](https://github.com/renovatebot/renovate/releases/tag/42.0.0) set the npmMinimumReleaseAge to 3 days which is lower than is set for PNPM in this repo. These changes are to override the [secuirty:minimumReleaseAgeNpm](https://docs.renovatebot.com/presets-security/#securityminimumreleaseagenpm) settings back to 7 days.
