### PR TITLE
chore(prettier): run format after update to 3.7

### DIFF
--- a/site/src/components/Hero.astro
+++ b/site/src/components/Hero.astro
@@ -50,8 +50,8 @@ import Title from "./Title.astro";
 
 		<div class="hero-description hero-description-secondary">
 			<p>
-				Tired of drive-by <em>"+1"</em> comments? Inaccessible images? Having to
-				bug contributors to complete issue and PR tasks?
+				Tired of drive-by <em>"+1"</em> comments? Inaccessible images? Having to bug
+				contributors to complete issue and PR tasks?
 			</p>
 			<p>
 				Let <strong>OctoGuide</strong> gently explain best practices and nudge contributors

--- a/site/src/components/OctoGuideGitHubComment.astro
+++ b/site/src/components/OctoGuideGitHubComment.astro
@@ -22,8 +22,8 @@ const { full, rule } = Astro.props;
 		<slot />
 
 		<blockquote class="octoguide-github-comment-footer">
-			<em class="octoguide-github-comment-footer-emoji">🗺️</em> This message was
-			posted automatically by
+			<em class="octoguide-github-comment-footer-emoji">🗺️</em> This message was posted
+			automatically by
 			<a href="/">OctoGuide</a>: a bot for GitHub repository best practices.
 		</blockquote>
 	</GitHubComment>

--- a/src/actors/EntityActorBase.ts
+++ b/src/actors/EntityActorBase.ts
@@ -22,9 +22,9 @@ interface UnminimizeCommentResponse {
 	};
 }
 
-export abstract class EntityActorBase<Data extends EntityData>
-	implements EntityActor<Data>
-{
+export abstract class EntityActorBase<
+	Data extends EntityData,
+> implements EntityActor<Data> {
 	abstract readonly metadata: Omit<Entity, "data">;
 
 	protected entityNumber: number;


### PR DESCRIPTION
>[!NOTE]
> This is a PR against an existing PR. It will not directly merge into main. It can be reviewed independently before it becomes a part of the renovate PR.

<!-- 👋 Hi, thanks for sending a PR to OctoGuide! 🗺️
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #386 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/JoshuaKGoldberg/OctoGuide/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/JoshuaKGoldberg/OctoGuide/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Ran `pnpm format --write` and committed the changes.

https://prettier.io/blog/2025/11/27/3.7.0
