### PR TITLE
ci: use app token for all-contributors-auto-action

### DIFF
--- a/.github/workflows/contributors.yml
+++ b/.github/workflows/contributors.yml
@@ -2,12 +2,12 @@ jobs:
   contributors:
     runs-on: ubuntu-latest
     steps:
-      - name: 🪙 Get app token
-        id: app-token
+      - id: app-token
+        name: 🪙 Get app token
         uses: actions/create-github-app-token@29824e69f54612133e76f7eaac726eef6c875baf # v2.2.1
         with:
-          private-key: ${{ secrets.all_contributors_private_key }}
           app-id: ${{ vars.all_contributors_app_id }}
+          private-key: ${{ secrets.all_contributors_private_key }}
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6
         with:
           fetch-depth: 0


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to OctoGuide! 🗺️
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #424 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/OctoGuide/bot/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/OctoGuide/bot/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
This uses [create-github-app-token](https://github.com/actions/create-github-app-token) to get a token from a github app `octoguide-all-contributors-auto` that was added to the repo. The app should have a higher rate limit that is not shared with other repos.