### PR TITLE
fix: pr-title-conventional should allow for breaking changes

### DIFF
--- a/src/rules/prTitleConventional.test.ts
+++ b/src/rules/prTitleConventional.test.ts
@@ -53,6 +53,58 @@ describe(prTitleConventional.about.name, () => {
 		});
 	});
 
+	it("reports when the pull request title has an unknown type with '!'", async () => {
+		const report = vi.fn();
+		const title = "other!: add this new feature";
+
+		await testRule(
+			prTitleConventional,
+			{
+				data: {
+					title,
+				},
+				type: "pull_request",
+			},
+			{ report },
+		);
+
+		expect(report).toHaveBeenCalledWith({
+			primary: `The PR title has an unknown type: 'other'.`,
+			secondary: [
+				"Known types are: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'",
+			],
+			suggestion: [
+				`To resolve this report, replace the current type with one of those known types, like _"feat: add this new feature"_.`,
+			],
+		});
+	});
+
+	it("reports when the pull request title has an unknown scoped type with '!'", async () => {
+		const report = vi.fn();
+		const title = "other(parser)!: add this new feature";
+
+		await testRule(
+			prTitleConventional,
+			{
+				data: {
+					title,
+				},
+				type: "pull_request",
+			},
+			{ report },
+		);
+
+		expect(report).toHaveBeenCalledWith({
+			primary: `The PR title has an unknown type: 'other'.`,
+			secondary: [
+				"Known types are: 'build', 'chore', 'ci', 'docs', 'feat', 'fix', 'perf', 'refactor', 'revert', 'style', 'test'",
+			],
+			suggestion: [
+				`To resolve this report, replace the current type with one of those known types, like _"feat: add this new feature"_.`,
+			],
+		});
+	});
+
 	it("reports when the pull request title is missing a subject", async () => {
 		const report = vi.fn();
 		const title = "feat: ";
@@ -84,6 +136,57 @@ describe(prTitleConventional.about.name, () => {
 			{
 				data: {
 					title: "feat: add this new feature",
+				},
+				type: "pull_request",
+			},
+			{ report },
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("does not report when the pull request title has a scoped conventional type", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prTitleConventional,
+			{
+				data: {
+					title: "feat(parser): add new feature",
+				},
+				type: "pull_request",
+			},
+			{ report },
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("does not report when the pull request title indicates a breaking change with '!'", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prTitleConventional,
+			{
+				data: {
+					title: "chore!: make breaking change",
+				},
+				type: "pull_request",
+			},
+			{ report },
+		);
+
+		expect(report).not.toHaveBeenCalled();
+	});
+
+	it("does not report when the pull request title indicates a scoped breaking change with '!'", async () => {
+		const report = vi.fn();
+
+		await testRule(
+			prTitleConventional,
+			{
+				data: {
+					title: "fix(parser)!: change parser API",
 				},
 				type: "pull_request",
 			},

--- a/src/rules/prTitleConventional.ts
+++ b/src/rules/prTitleConventional.ts
@@ -6,7 +6,14 @@ import { CommitParser } from "conventional-commits-parser";
 
 import { defineRule } from "./defineRule.js";
 
-const commitParser = new CommitParser();
+// Configuring the parser to recognize breaking-change headers that
+// include a `!` before the colon (e.g., `fix!: ...` or `fix(scope)!: ...`).
+// (see https://github.com/conventional-changelog/conventional-changelog/issues/648)
+// This helps the parser populate `parsed.type` correctly in more cases.
+const commitParser = new CommitParser({
+	// Matches: type, optional (scope), '!' and the subject
+	breakingHeaderPattern: /^(\w*)(?:\((.*)\))?!: (.*)$/,
+});
 
 export const prTitleConventional = defineRule({
 	about: {


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to OctoGuide! 🗺️
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #422 
- [x] That issue was marked as [`status: accepting prs`](https://github.com/OctoGuide/bot/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/OctoGuide/bot/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Configures parser with `breakingHeaderPattern` so that pr-title-conventional correctly allows for conventional commit breaking changes using the `!`.

❗
