### PR TITLE
ci: add self-hosted renovate workflow

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -23,4 +23,4 @@ jobs:
 name: 🏚 Renovate
 on:
   schedule:
-    - cron: "0/15 * * * *" # every 15 minutes
+    - cron: "0 */4 * * *" # every 4 hours


### PR DESCRIPTION
<!-- 👋 Hi, thanks for sending a PR to OctoGuide! 🗺️
Please fill out all fields below and make sure each item is true and [x] checked.
Otherwise we may not be able to review your PR. -->

## PR Checklist

- [x] Addresses an existing open issue: fixes #445
- [x] That issue was marked as [`status: accepting prs`](https://github.com/OctoGuide/bot/issues?q=is%3Aopen+is%3Aissue+label%3A%22status%3A+accepting+prs%22)
- [x] Steps in [CONTRIBUTING.md](https://github.com/OctoGuide/bot/blob/main/.github/CONTRIBUTING.md) were taken

## Overview

<!-- Description of what is changed and how the code change does that. -->
Sets up workflow to run renovate self hosted in github actions.
https://github.com/renovatebot/github-action#example-with-github-app

🤖